### PR TITLE
Rename plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,93 @@
+language: php
+
+sudo: false
+
+addons:
+  postgresql: "9.3"
+  apt:
+    packages:
+      - oracle-java8-installer
+      - oracle-java8-set-default
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.npm
+
+php:
+ - 7.0
+ - 7.1
+
+matrix:
+  allow_failures:
+  - env: DB=pgsql MOODLE_BRANCH=master
+  - env: DB=mysqli MOODLE_BRANCH=master
+  #exclude:
+  #- php: 5.6
+  #  env: DB=pgsql MOODLE_BRANCH=master
+
+  fast_finish: true
+
+env:
+ global:
+  - BEHAT=yes
+  - MUSTACHE_IGNORE_NAMES="email_html_body.mustache, email_html.mustache, email_text.mustache"
+ matrix:
+  - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=pgsql MOODLE_BRANCH=master
+  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=mysqli MOODLE_BRANCH=master
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - nvm install --lts
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+jobs:
+  include:
+    # Prechecks against latest Moodle stable only.
+    - stage: static
+      php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+      install:
+      - moodle-plugin-ci install --no-init
+      script:
+      - moodle-plugin-ci phplint
+      - moodle-plugin-ci phpcpd
+      - moodle-plugin-ci phpmd
+      - moodle-plugin-ci codechecker
+      - moodle-plugin-ci validate
+      - moodle-plugin-ci savepoints
+      - moodle-plugin-ci mustache
+      - moodle-plugin-ci grunt
+
+    # Smaller build matrix for development builds
+    - stage: develop
+      php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+      install:
+      - moodle-plugin-ci install
+      script:
+      - moodle-plugin-ci phpunit --coverage-clover
+      - moodle-plugin-ci behat
+
+# Default 'test' stage: Unit tests and behat tests against full matrix.
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phpunit --coverage-clover
+  - moodle-plugin-ci behat
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+stages:
+  - static
+  - name: develop
+    if: branch != master AND (type != pull_request OR head_branch != master) AND (tag IS blank)
+  - name: test
+    if: branch = master OR (type = pull_request AND head_branch = master) OR (tag IS present)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The plugin aims to make users **anonymous** that are suspended.
 
 This includes:
 
-- save necessary data in a shadow table to reactivate users when necessary. (name of the table: `cleanupusers_archive`)
+- save necessary data in a shadow table to reactivate users when necessary. (name of the table: `tool_cleanupusers_archive`)
 - hide all other references in the `user` table e.g. `username`, ` firstname` etc.
     - the `username` is set to *Anonym* with the `userid` appended
         - usernames must be unique therefore the id is appended.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# moodle-tool_deprovisionuser *(Alpha_candidate)*
+# moodle-tool_cleanupusers *(Alpha_candidate)*
 </br>
 
-The **deprovisionuser plugin** enables the automatic and manual deletion and suspension of users.
+The **clean up users plugin** enables the automatic and manual suspension and deletion of users.
 
 The plugin is written by [Jan Dageförde](https://github.com/Dagefoerde), [Tobias Reischmann](https://github.com/tobiasreischmann) and [Nina Herrmann](https://github.com/NinaHerrmann).
 
@@ -13,8 +13,8 @@ Therefore, the plugin aims to automatically suspend and delete users to custom r
 
 ## Installation
 
-This plugin should go into `admin/tool/deprovisionuser`. 
-No supplementary settings are required in the **deprovisionuser plugin**. 
+This plugin should go into `admin/tool/cleanupusers`. 
+No supplementary settings are required in the **clean up users plugin**. 
 Optionally the sub-plugin can be changed in `Home ► Site administration ► Users ► Deprovision of Users`. 
 By default, the **userstatuswwu sub-plugin** is used. 
 However, it is likely that the sub-plugin requires additional settings therefore please read the information for the [sub-plugins](#sub-plugins). 
@@ -47,7 +47,7 @@ The plugin aims to make users **anonymous** that are suspended.
 
 This includes:
 
-- save necessary data in a shadow table to reactivate users when necessary. (name of the table: `deprovisionuser_archive`)
+- save necessary data in a shadow table to reactivate users when necessary. (name of the table: `cleanupusers_archive`)
 - hide all other references in the `user` table e.g. `username`, ` firstname` etc.
     - the `username` is set to *Anonym* with the `userid` appended
         - usernames must be unique therefore the id is appended.
@@ -92,7 +92,7 @@ To check the technical implementation, look at `/lib/moodlelib.php`.
 
 The Plugin requires at least one sub-plugin that returns users to be handled by the cronjob. 
 Every university can write their own sub-plugin which specifies the conditions to delete, archive and 
-reactivate users. An Interface is included in the directory `deprovisionuser/classes`. 
+reactivate users. An Interface is included in the directory `cleanupusers/classes`. 
 
 The sub-plugin needs to implement four functions:
  - get_to_suspend()

--- a/classes/archiveduser.php
+++ b/classes/archiveduser.php
@@ -16,11 +16,11 @@
 /**
  * Class archive user.
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-namespace tool_deprovisionuser;
+namespace tool_cleanupusers;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -32,7 +32,7 @@ use \core\session\manager;
  * The class collects the necessary information to suspend, delete and activate users.
  * It can be used in sub-plugins, since the constructor assures that all necessary information is transferred.
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -73,10 +73,10 @@ class archiveduser {
     /**
      * Suspends the user.
      *
-     * Therefore makes an entry in the tool_deprovisionuser table. Throws an error when the user that should be
+     * Therefore makes an entry in the tool_cleanupusers table. Throws an error when the user that should be
      * suspended is already suspended or is the sideadmin.
      *
-     * @throws deprovisionuser_exception
+     * @throws cleanupusers_exception
      */
     public function archive_me() {
         global $DB;
@@ -93,22 +93,22 @@ class archiveduser {
             user_update_user($user, false);
 
             $timestamp = time();
-            $tooluser = $DB->get_record('tool_deprovisionuser', array('id' => $user->id));
+            $tooluser = $DB->get_record('tool_cleanupusers', array('id' => $user->id));
 
             // Document time of editing user in Database.
             // In case there is no entry in the tool table make a new one.
             if (empty($tooluser)) {
-                $DB->insert_record_raw('tool_deprovisionuser', array('id' => $user->id, 'archived' => $user->suspended,
+                $DB->insert_record_raw('tool_cleanupusers', array('id' => $user->id, 'archived' => $user->suspended,
                     'timestamp' => $timestamp), true, false, true);
             } else {
                 // In case an record already exist the timestamp is updated.
                 $tooluser->timestamp = $timestamp;
-                $DB->update_record('tool_deprovisionuser', $tooluser);
+                $DB->update_record('tool_cleanupusers', $tooluser);
             }
 
             // Insert copy of user in second DB and replace user in main table when entry was successful.
             $shadowuser = clone $user;
-            $success = $DB->insert_record_raw('deprovisionuser_archive', $shadowuser, true, false, true);
+            $success = $DB->insert_record_raw('cleanupusers_archive', $shadowuser, true, false, true);
             if ($success == true) {
                 // Replaces the current user with a pseudo_user that has no reference.
                 $cloneuser = $this->give_suspended_pseudo_user($shadowuser->id, $timestamp);
@@ -117,17 +117,17 @@ class archiveduser {
             $transaction->allow_commit();
             // No error here since user was maybe manually suspended in user table.
         } else {
-            throw new deprovisionuser_exception(get_string('errormessagenotsuspend', 'tool_deprovisionuser'));
+            throw new cleanupusers_exception(get_string('errormessagenotsuspend', 'tool_cleanupusers'));
         }
     }
 
     /**
      * Reactivates the user.
      *
-     * Therefore deletes the entry in the tool_deprovisionuser table and throws an exception when no entry is available
+     * Therefore deletes the entry in the tool_cleanupusers table and throws an exception when no entry is available
      * or the name of the user is 'Anonym' at the end of the function.
      *
-     * @throws deprovisionuser_exception
+     * @throws cleanupusers_exception
      */
     public function activate_me() {
         global $DB;
@@ -147,25 +147,25 @@ class archiveduser {
         } else {
             // The user was archived by the plugin.
 
-            // Deletes record of plugin table tool_deprovisionuser.
-            if (!empty($DB->get_records('tool_deprovisionuser', array('id' => $user->id)))) {
-                $DB->delete_records('tool_deprovisionuser', array('id' => $user->id));
+            // Deletes record of plugin table tool_cleanupusers.
+            if (!empty($DB->get_records('tool_cleanupusers', array('id' => $user->id)))) {
+                $DB->delete_records('tool_cleanupusers', array('id' => $user->id));
             }
 
-            // Is user in the shadow table (deprovisionuser_archive table)?
-            if (empty($DB->get_record('deprovisionuser_archive', array('id' => $user->id)))) {
+            // Is user in the shadow table (cleanupusers_archive table)?
+            if (empty($DB->get_record('cleanupusers_archive', array('id' => $user->id)))) {
 
                 // If there is no user, the main table can not be updated.
-                throw new deprovisionuser_exception(get_string('errormessagenotactive', 'tool_deprovisionuser'));
+                throw new cleanupusers_exception(get_string('errormessagenotactive', 'tool_cleanupusers'));
 
             } else {
                 // If the user is in table replace data.
-                $shadowuser = $DB->get_record('deprovisionuser_archive', array('id' => $user->id));
+                $shadowuser = $DB->get_record('cleanupusers_archive', array('id' => $user->id));
                 $shadowuser->suspended = 0;
 
                 $DB->update_record('user', $shadowuser);
-                // Delete records from deprovisionuser_archive table.
-                $DB->delete_records('deprovisionuser_archive', array('id' => $user->id));
+                // Delete records from cleanupusers_archive table.
+                $DB->delete_records('cleanupusers_archive', array('id' => $user->id));
             }
             // Gets the new user for additional checks.
             $transaction->allow_commit();
@@ -173,7 +173,7 @@ class archiveduser {
 
             // When username is still 'Anonym' something went wrong.
             if ($user->firstname == 'Anonym') {
-                throw new deprovisionuser_exception(get_string('errormessagenotactive', 'tool_deprovisionuser'));
+                throw new cleanupusers_exception(get_string('errormessagenotactive', 'tool_cleanupusers'));
             }
         }
     }
@@ -182,13 +182,13 @@ class archiveduser {
      * Deletes the user.
      *
      * Therefore
-     * (1) Deletes the entry in the tool_deprovisionuser and the deprovisionuser_archive table.
+     * (1) Deletes the entry in the tool_cleanupusers and the cleanupusers_archive table.
      * (2) Hashes the username with the sha256 function.
      * (3) Calls the moodle core delete_user function..
      *
      * Throws an error when the side admin should be deleted or user is already flagged as deleted.
      *
-     * @throws deprovisionuser_exception
+     * @throws cleanupusers_exception
      */
     public function delete_me() {
         global $DB;
@@ -201,12 +201,12 @@ class archiveduser {
             $transaction = $DB->start_delegated_transaction();
 
             // Deletes the records in both plugin tables.
-            if (!empty($DB->get_records('tool_deprovisionuser', array('id' => $user->id)))) {
-                $DB->delete_records('tool_deprovisionuser', array('id' => $user->id));
+            if (!empty($DB->get_records('tool_cleanupusers', array('id' => $user->id)))) {
+                $DB->delete_records('tool_cleanupusers', array('id' => $user->id));
             }
 
-            if (!empty($DB->get_records('deprovisionuser_archive', array('id' => $user->id)))) {
-                $DB->delete_records('deprovisionuser_archive', array('id' => $user->id));
+            if (!empty($DB->get_records('cleanupusers_archive', array('id' => $user->id)))) {
+                $DB->delete_records('cleanupusers_archive', array('id' => $user->id));
             }
 
             // To secure that plugins that reference the user table do not fail create empty user with a hash as username.
@@ -235,7 +235,7 @@ class archiveduser {
             delete_user($user);
             $transaction->allow_commit();
         } else {
-            throw new deprovisionuser_exception(get_string('errormessagenotdelete', 'tool_deprovisionuser'));
+            throw new cleanupusers_exception(get_string('errormessagenotdelete', 'tool_cleanupusers'));
         }
     }
 

--- a/classes/archiveduser.php
+++ b/classes/archiveduser.php
@@ -108,7 +108,7 @@ class archiveduser {
 
             // Insert copy of user in second DB and replace user in main table when entry was successful.
             $shadowuser = clone $user;
-            $success = $DB->insert_record_raw('cleanupusers_archive', $shadowuser, true, false, true);
+            $success = $DB->insert_record_raw('tool_cleanupusers_archive', $shadowuser, true, false, true);
             if ($success == true) {
                 // Replaces the current user with a pseudo_user that has no reference.
                 $cloneuser = $this->give_suspended_pseudo_user($shadowuser->id, $timestamp);
@@ -152,20 +152,20 @@ class archiveduser {
                 $DB->delete_records('tool_cleanupusers', array('id' => $user->id));
             }
 
-            // Is user in the shadow table (cleanupusers_archive table)?
-            if (empty($DB->get_record('cleanupusers_archive', array('id' => $user->id)))) {
+            // Is user in the shadow table (tool_cleanupusers_archive table)?
+            if (empty($DB->get_record('tool_cleanupusers_archive', array('id' => $user->id)))) {
 
                 // If there is no user, the main table can not be updated.
                 throw new cleanupusers_exception(get_string('errormessagenotactive', 'tool_cleanupusers'));
 
             } else {
                 // If the user is in table replace data.
-                $shadowuser = $DB->get_record('cleanupusers_archive', array('id' => $user->id));
+                $shadowuser = $DB->get_record('tool_cleanupusers_archive', array('id' => $user->id));
                 $shadowuser->suspended = 0;
 
                 $DB->update_record('user', $shadowuser);
-                // Delete records from cleanupusers_archive table.
-                $DB->delete_records('cleanupusers_archive', array('id' => $user->id));
+                // Delete records from tool_cleanupusers_archive table.
+                $DB->delete_records('tool_cleanupusers_archive', array('id' => $user->id));
             }
             // Gets the new user for additional checks.
             $transaction->allow_commit();
@@ -182,7 +182,7 @@ class archiveduser {
      * Deletes the user.
      *
      * Therefore
-     * (1) Deletes the entry in the tool_cleanupusers and the cleanupusers_archive table.
+     * (1) Deletes the entry in the tool_cleanupusers and the tool_cleanupusers_archive table.
      * (2) Hashes the username with the sha256 function.
      * (3) Calls the moodle core delete_user function..
      *
@@ -205,8 +205,8 @@ class archiveduser {
                 $DB->delete_records('tool_cleanupusers', array('id' => $user->id));
             }
 
-            if (!empty($DB->get_records('cleanupusers_archive', array('id' => $user->id)))) {
-                $DB->delete_records('cleanupusers_archive', array('id' => $user->id));
+            if (!empty($DB->get_records('tool_cleanupusers_archive', array('id' => $user->id)))) {
+                $DB->delete_records('tool_cleanupusers_archive', array('id' => $user->id));
             }
 
             // To secure that plugins that reference the user table do not fail create empty user with a hash as username.

--- a/classes/cleanupusers_exception.php
+++ b/classes/cleanupusers_exception.php
@@ -14,25 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Create an additional Exception Class for the tool_deprovisionuser_subplugins.
+ * Create an Exception Class for the tool_cleanupusers
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace tool_deprovisionuser;
+namespace tool_cleanupusers;
 
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Class deprovisionuser_subplugin_exception
+ * Exception Class for the tool_cleanupusers.
  *
- * @package tool_deprovisionuser
- * @copyright 2016 N. Herrmann
+ * @package   tool_cleanupusers
+ * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class deprovisionuser_subplugin_exception extends \moodle_exception {
+class cleanupusers_exception extends \moodle_exception {
+
     /**
      * Constructor
      * @param string $errorcode The name of the string from webservice.php to print
@@ -40,6 +41,6 @@ class deprovisionuser_subplugin_exception extends \moodle_exception {
      * @param string $debuginfo Optional information to aid debugging
      */
     public function __construct($errorcode, $a = '', $debuginfo = null) {
-        parent::__construct($errorcode, 'tool_deprovisionuser', '', $a, $debuginfo);
+        parent::__construct($errorcode, 'tool_cleanupusers', '', $a, $debuginfo);
     }
 }

--- a/classes/cleanupusers_subplugin_exception.php
+++ b/classes/cleanupusers_subplugin_exception.php
@@ -14,26 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Create an Exception Class for the tool_deprovisionuser
+ * Create an additional Exception Class for the cleanupusers_subplugins.
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace tool_deprovisionuser;
+namespace tool_cleanupusers;
 
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Exception Class for the tool_deprovisionuser.
+ * Class cleanupusers_subplugin_exception
  *
- * @package   tool_deprovisionuser
- * @copyright 2017 N. Herrmann
+ * @package tool_cleanupusers
+ * @copyright 2016 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class deprovisionuser_exception extends \moodle_exception {
-
+class cleanupusers_subplugin_exception extends \moodle_exception {
     /**
      * Constructor
      * @param string $errorcode The name of the string from webservice.php to print
@@ -41,6 +40,6 @@ class deprovisionuser_exception extends \moodle_exception {
      * @param string $debuginfo Optional information to aid debugging
      */
     public function __construct($errorcode, $a = '', $debuginfo = null) {
-        parent::__construct($errorcode, 'tool_deprovisionuser', '', $a, $debuginfo);
+        parent::__construct($errorcode, 'tool_cleanupusers', '', $a, $debuginfo);
     }
 }

--- a/classes/event/deprovisionusercronjob_completed.php
+++ b/classes/event/deprovisionusercronjob_completed.php
@@ -15,21 +15,21 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * The tool_deprovisionuser cron job complete event.
+ * The tool_cleanupusers cron job complete event.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace tool_deprovisionuser\event;
+namespace tool_cleanupusers\event;
 defined('MOODLE_INTERNAL') || die();
 
 use \core\event\base;
 /**
- * The tool_deprovisionuser event informs admin about outcome of cron-job.
+ * The tool_cleanupusers event informs admin about outcome of cron-job.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -59,7 +59,7 @@ class deprovisionusercronjob_completed extends base {
      * @return string
      */
     public static function get_name() {
-        return get_string('cronjobcomplete', 'tool_deprovisionuser');
+        return get_string('cronjobcomplete', 'tool_cleanupusers');
     }
 
 
@@ -76,11 +76,11 @@ class deprovisionusercronjob_completed extends base {
 
         // If no user was affected...
         if (empty($archived) and empty($deleted)) {
-            return get_string('cronjobwasrunning', 'tool_deprovisionuser');
+            return get_string('cronjobwasrunning', 'tool_cleanupusers');
         } else {
             // Otherwise number of users affected.
-            return get_string('e-mail-archived', 'tool_deprovisionuser', $archived) . ' ' .
-                get_string('e-mail-deleted', 'tool_deprovisionuser', $deleted);
+            return get_string('e-mail-archived', 'tool_cleanupusers', $archived) . ' ' .
+                get_string('e-mail-deleted', 'tool_cleanupusers', $deleted);
         }
     }
 }

--- a/classes/plugininfo/userstatus.php
+++ b/classes/plugininfo/userstatus.php
@@ -18,12 +18,12 @@
  * The Plugins of the type userstatus must return values whether users should be deleted, archived or reactivated.
  * The sub-plugins will be used by the cron-job and manually by the admin to determine the appropriate actions for users.
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2016/17 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace tool_deprovisionuser\plugininfo;
+namespace tool_cleanupusers\plugininfo;
 
 use admin_settingpage;
 use core\plugininfo\base;
@@ -34,7 +34,7 @@ defined('MOODLE_INTERNAL') || die();
  * The general settings for all sub-plugins of userstatus.
  * Defines the deinstallation settings and adds sub-plugins to the admin tree, if they have a settings.php.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -54,8 +54,7 @@ class userstatus extends base {
             return false;
         }
         // In case the sub-plugin is in use, sub-plugin can not be uninstalled.
-        if (!empty(get_config('tool_deprovisionuser', 'deprovisionuser_subplugin'))) {
-            $subplugin = get_config('tool_deprovisionuser', 'deprovisionuser_subplugin');
+        if (!empty($subplugin = get_config('tool_cleanupusers', 'cleanupusers_subplugin'))) {
             if ($subplugin == $this->name) {
                 return false;
             }
@@ -96,6 +95,6 @@ class userstatus extends base {
      * @return string
      */
     public function get_settings_section_name() {
-        return 'deprovisionuser_userstatus' . $this->name;
+        return 'cleanupusers_userstatus' . $this->name;
     }
 }

--- a/classes/subplugin_select_form.php
+++ b/classes/subplugin_select_form.php
@@ -14,14 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Create an Form Class for the tool_deprovisionuser
+ * Create an Form Class for the tool_cleanupusers
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace tool_deprovisionuser;
+namespace tool_cleanupusers;
 defined('MOODLE_INTERNAL') || die();
 
 require_once("$CFG->libdir/formslib.php");
@@ -31,7 +31,7 @@ use core_plugin_manager;
 /**
  * Form Class which allows the sideadmin to select between the available sub-plugins.
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -51,7 +51,7 @@ class subplugin_select_form extends moodleform {
             $types[$value->name] = $value->name;
         }
 
-        $ispluginselected = empty(get_config('tool_deprovisionuser'));
+        $ispluginselected = empty(get_config('tool_cleanupusers'));
         // Different text in case no plugin was selected beforehand.
         if ($ispluginselected) {
             $text = 'Please select a subplugin';
@@ -62,7 +62,7 @@ class subplugin_select_form extends moodleform {
 
         // If a plugin is active it is shown as the default.
         if (!$ispluginselected) {
-            $mform->setDefault('subplugin', get_config('tool_deprovisionuser', 'deprovisionuser_subplugin'));
+            $mform->setDefault('subplugin', get_config('tool_cleanupusers', 'cleanupusers_subplugin'));
         }
         $mform->addElement('submit', 'reset', 'Submit');
     }
@@ -85,8 +85,8 @@ class subplugin_select_form extends moodleform {
             }
         }
         if ($issubplugin == false) {
-            $issubplugin['subplugin'] = new deprovisionuser_subplugin_exception
-            (get_string('errormessagesubplugin', 'tool_deprovisionuser'));
+            $issubplugin['subplugin'] = new cleanupusers_subplugin_exception
+            (get_string('errormessagesubplugin', 'tool_cleanupusers'));
         }
         return $issubplugin;
     }

--- a/classes/userstatusinterface.php
+++ b/classes/userstatusinterface.php
@@ -25,16 +25,16 @@
  * (3) lastaccess
  * (3) suspended
  * (3) deleted
- * You can assure that the information is given when you use the tool_deprovisionuser_archiveuser class.
+ * You can assure that the information is given when you use the tool_cleanupusers_archiveuser class.
  *
  * This Plugin will be used by the cron_job and manually by the admin to determine the appropriate actions for users.
  *
- * @see       \tool_deprovisionuser\archiveduser
- * @package   tool_deprovisionuser
+ * @see       \tool_cleanupusers\archiveduser
+ * @package   tool_cleanupusers
  * @copyright 2016/17 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-namespace tool_deprovisionuser;
+namespace tool_cleanupusers;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="tool/deprovisionuser/db" VERSION="20120122" COMMENT="XMLDB file for Moodle tool/deprovisionuser"
+<XMLDB PATH="tool/cleanupusers/db" VERSION="20120122" COMMENT="XMLDB file for Moodle tool/cleanupusers"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
     <TABLES>
-        <TABLE NAME="tool_deprovisionuser" COMMENT="deprovision user">
+        <TABLE NAME="tool_cleanupusers" COMMENT="deprovision user">
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
                 // Copied from mdl_user.
@@ -17,7 +17,7 @@
                 <KEY NAME="foreign" TYPE="foreign" FIELDS="id" REFTABLE="user" REFFIELDS="id"/>
             </KEYS>
         </TABLE>
-        <TABLE NAME="deprovisionuser_archive" COMMENT="deprovision user">
+        <TABLE NAME="cleanupusers_archive" COMMENT="deprovision user">
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
                 // Copied from mdl_user.

--- a/db/install.xml
+++ b/db/install.xml
@@ -17,7 +17,7 @@
                 <KEY NAME="foreign" TYPE="foreign" FIELDS="id" REFTABLE="user" REFFIELDS="id"/>
             </KEYS>
         </TABLE>
-        <TABLE NAME="cleanupusers_archive" COMMENT="deprovision user">
+        <TABLE NAME="tool_cleanupusers_archive" COMMENT="deprovision user">
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
                 // Copied from mdl_user.

--- a/db/subplugins.php
+++ b/db/subplugins.php
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * This file defines the sub-plugins for the deprovisionuser admin tool.
+ * This file defines the sub-plugins for the cleanupusers admin tool.
  *
- * @package tool_deprovisionuser
+ * @package tool_cleanupusers
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$subplugins = array('userstatus' => 'admin/tool/deprovisionuser/userstatus');
+$subplugins = array('userstatus' => 'admin/tool/cleanupusers/userstatus');

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -16,7 +16,7 @@
 /**
  * Tasks definition.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $tasks = array(
     array(
-        'classname' => 'tool_deprovisionuser\task\archive_user_task',
+        'classname' => 'tool_cleanupusers\task\archive_user_task',
         'blocking' => 0,
         'minute' => 'R',
         'hour' => '4',

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Upgrade for the tool_deprovisionuser.
+ * Upgrade for the tool_cleanupusers.
  *
- * @package tool_deprovisionuser
+ * @package tool_cleanupusers
  * @copyright 2016/17 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -24,9 +24,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Function to upgrade for the tool_deprovisionuser.
+ * Function to upgrade for the tool_cleanupusers.
  */
 
-function xmldb_tool_deprovisionuser_upgrade($oldversion) {
+function xmldb_tool_cleanupusers_upgrade($oldversion) {
     return true;
 }

--- a/handleuser.php
+++ b/handleuser.php
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Suspend, delete or reactivate user. This is called when sideadmin changes user from the deprovisionuser
+ * Suspend, delete or reactivate user. This is called when sideadmin changes user from the cleanupusers
  * administration page.
  *
- * @package tool_deprovision
+ * @package tool_cleanupusers
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -30,73 +30,73 @@ $userid         = required_param('userid', PARAM_INT);
 // One of: suspend, reactivate or delete.
 $action         = required_param('action', PARAM_TEXT);
 
-$PAGE->set_url('/admin/tool/deprovisionuser/handleuser.php');
+$PAGE->set_url('/admin/tool/cleanupusers/handleuser.php');
 $PAGE->set_context(context_system::instance());
 
 $user = $DB->get_record('user', array('id' => $userid));
 require_capability('moodle/user:update', $PAGE->context);
 
-$url = new moodle_url('/admin/tool/deprovisionuser/index.php');
+$url = new moodle_url('/admin/tool/cleanupusers/index.php');
 
 switch($action){
     // User should be suspended.
     case 'suspend':
         // Sideadmins, the current $USER and user who are already suspended can not be handeled.
         if (!is_siteadmin($user) and $user->suspended != 1 and $USER->id != $userid) {
-            $deprovisionuser = new \tool_deprovisionuser\archiveduser($userid, $user->suspended, $user->lastaccess,
+            $deprovisionuser = new \tool_cleanupusers\archiveduser($userid, $user->suspended, $user->lastaccess,
                 $user->username, $user->deleted);
             try {
                 $deprovisionuser->archive_me();
-            } catch (\tool_deprovisionuser\deprovisionuser_exception $e) {
+            } catch (\tool_cleanupusers\cleanupusers_exception $e) {
                 // Notice user could not be suspended.
-                notice(get_string('errormessagenoaction', 'tool_deprovisionuser'), $url);
+                notice(get_string('errormessagenoaction', 'tool_cleanupusers'), $url);
             }
             // User was successfully suspended.
-            notice(get_string('usersarchived', 'tool_deprovisionuser'), $url);
+            notice(get_string('usersarchived', 'tool_cleanupusers'), $url);
         } else {
             // Notice user could not be suspended.
-            notice(get_string('errormessagenotsuspend', 'tool_deprovisionuser'), $url);
+            notice(get_string('errormessagenotsuspend', 'tool_cleanupusers'), $url);
         }
         break;
     // User should be reactivated.
     case 'reactivate':
         if (!is_siteadmin($user) and $user->suspended != 0 and $USER->id != $userid) {
-            $deprovisionuser = new \tool_deprovisionuser\archiveduser($userid, $user->suspended, $user->lastaccess,
+            $deprovisionuser = new \tool_cleanupusers\archiveduser($userid, $user->suspended, $user->lastaccess,
                 $user->username, $user->deleted);
             try {
                 $deprovisionuser->activate_me();
-            } catch (\tool_deprovisionuser\deprovisionuser_exception $e) {
+            } catch (\tool_cleanupusers\cleanupusers_exception $e) {
                 // Notice user could not be reactivated.
-                notice(get_string('errormessagenoaction', 'tool_deprovisionuser'), $url);
+                notice(get_string('errormessagenoaction', 'tool_cleanupusers'), $url);
             }
             // User successfully reactivated.
-            notice(get_string('usersreactivated', 'tool_deprovisionuser'), $url);
+            notice(get_string('usersreactivated', 'tool_cleanupusers'), $url);
         } else {
             // Notice user could not be reactivated.
-            notice(get_string('errormessagenotactive', 'tool_deprovisionuser'), $url);
+            notice(get_string('errormessagenotactive', 'tool_cleanupusers'), $url);
         }
         break;
     // User should be deleted.
     case 'delete':
         if (!is_siteadmin($user) and $user->deleted != 1 and $USER->id != $userid) {
-            $deprovisionuser = new \tool_deprovisionuser\archiveduser($userid, $user->suspended, $user->lastaccess,
+            $deprovisionuser = new \tool_cleanupusers\archiveduser($userid, $user->suspended, $user->lastaccess,
                 $user->username, $user->deleted);
             try {
                 $deprovisionuser->delete_me();
-            } catch (\tool_deprovisionuser\deprovisionuser_exception $e) {
-                $url = new moodle_url('/admin/tool/deprovisionuser/index.php');
+            } catch (\tool_cleanupusers\cleanupusers_exception $e) {
+                $url = new moodle_url('/admin/tool/cleanupusers/index.php');
                 // Notice user could not be deleted.
-                notice(get_string('errormessagenoaction', 'tool_deprovisionuser'), $url);
+                notice(get_string('errormessagenoaction', 'tool_cleanupusers'), $url);
             }
-            notice(get_string('usersdeleted', 'tool_deprovisionuser'), $url);
+            notice(get_string('usersdeleted', 'tool_cleanupusers'), $url);
         } else {
             // Notice user could not be deleted.
-            notice(get_string('errormessagenoaction', 'tool_deprovisionuser'), $url);
+            notice(get_string('errormessagenoaction', 'tool_cleanupusers'), $url);
         }
         break;
     // Action is not valid.
     default:
-        notice(get_string('errormessagenoaction', 'tool_deprovisionuser'), $url);
+        notice(get_string('errormessagenoaction', 'tool_cleanupusers'), $url);
         break;
 }
 exit();

--- a/index.php
+++ b/index.php
@@ -15,13 +15,13 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Web interface to deprovisionuser.
+ * Web interface to cleanupusers.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(dirname(__FILE__) . '/../../../config.php');
+require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir.'/adminlib.php');
 
 // Get URL parameters.
@@ -32,21 +32,21 @@ $context = context_system::instance();
 require_login();
 require_capability('moodle/site:config', $context);
 
-admin_externalpage_setup('deprovisionuser');
+admin_externalpage_setup('cleanupusers');
 
-$pagetitle = get_string('pluginname', 'tool_deprovisionuser');
-$PAGE->set_title(get_string('pluginname', 'tool_deprovisionuser'));
-$PAGE->set_heading(get_string('pluginname', 'tool_deprovisionuser'));
+$pagetitle = get_string('pluginname', 'tool_cleanupusers');
+$PAGE->set_title(get_string('pluginname', 'tool_cleanupusers'));
+$PAGE->set_heading(get_string('pluginname', 'tool_cleanupusers'));
 $PAGE->set_pagelayout('standard');
 
-$renderer = $PAGE->get_renderer('tool_deprovisionuser');
+$renderer = $PAGE->get_renderer('tool_cleanupusers');
 
 $content = '';
 echo $OUTPUT->header();
 echo $renderer->get_heading();
 $content = '';
 
-$mform = new \tool_deprovisionuser\subplugin_select_form();
+$mform = new \tool_cleanupusers\subplugin_select_form();
 $formdata = $mform->get_data();
 $datavalidated = false;
 if (!empty($formdata)) {
@@ -55,7 +55,7 @@ if (!empty($formdata)) {
 }
 // In this case you process validated data.
 if ($datavalidated && !empty($arraydata['subplugin'])) {
-    set_config('deprovisionuser_subplugin', $arraydata['subplugin'], 'tool_deprovisionuser');
+    set_config('cleanupusers_subplugin', $arraydata['subplugin'], 'tool_cleanupusers');
     $content = 'You successfully submitted the Subplugin.';
     $mform->display();
 } else {
@@ -65,8 +65,8 @@ if ($datavalidated && !empty($arraydata['subplugin'])) {
     $mform->display();
 }
 // Assures right sub-plugin is used.
-if (!empty(get_config('tool_deprovisionuser', 'deprovisionuser_subplugin'))) {
-    $subplugin = get_config('tool_deprovisionuser', 'deprovisionuser_subplugin');
+if (!empty(get_config('tool_cleanupusers', 'cleanupusers_subplugin'))) {
+    $subplugin = get_config('tool_cleanupusers', 'cleanupusers_subplugin');
     $mysubpluginname = "\\userstatus_" . $subplugin . "\\" . $subplugin;
     $userstatuschecker = new $mysubpluginname();
 } else {

--- a/lang/en/tool_cleanupusers.php
+++ b/lang/en/tool_cleanupusers.php
@@ -14,19 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * This file contains language strings used in the deprovisionuser admin tool.
+ * This file contains language strings used in the cleanupusers admin tool.
  *
- * @package tool_deprovisionuser
+ * @package tool_cleanupusers
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = 'deprovisionuser';
-$string['plugintitel'] = 'Deprovision of Users';
-$string['subplugintype_userstatus'] = 'Returns the Status of Students';
-$string['subplugintype_userstatus_plural'] = 'Returns the Status of Students';
+$string['pluginname'] = 'Clean up users';
+$string['plugintitel'] = 'Clean up users';
+$string['subplugintype_userstatus'] = 'Returns the status of users';
+$string['subplugintype_userstatus_plural'] = 'Returns the status of users';
 $string['oldusers'] = 'Users';
-$string['lastaccess'] = 'Last Access:';
+$string['lastaccess'] = 'Last access:';
 $string['usersarchived'] = 'The Users have been archived';
 $string['Yes'] = 'Yes';
 $string['No'] = 'No';
@@ -34,8 +34,8 @@ $string['Archived'] = 'Archived:';
 $string['Willbe'] = 'Will be:';
 $string['Neverloggedin'] = 'User that never logged in:';
 $string['titletodelete'] = 'Delete Users';
-$string['usersdeleted'] = 'The User has been deleted.';
-$string['usersreactivated'] = 'The User has been reactivated.';
+$string['usersdeleted'] = 'The user has been deleted.';
+$string['usersreactivated'] = 'The user has been reactivated.';
 $string['showuser'] = 'Activate User';
 $string['hideuser'] = 'Suspend User';
 $string['deleteuser'] = 'Delete User';
@@ -56,7 +56,7 @@ $string['errormessagesubplugin'] = 'The sub-plugin you selected is not available
 $string['e-mail-problematic_delete'] = 'In the last cron-job {$a} users caused exception and could not be deleted.';
 $string['e-mail-problematic_suspend'] = 'In the last cron-job {$a} users caused exception and could not be suspended.';
 $string['e-mail-problematic_reactivate'] = 'In the last cron-job {$a} users caused exception and could not be reactivated.';
-$string['e-mail-noproblem'] = 'No problems occurred in plugin tool_deprovisionuser in the last run.';
-$string['cronjobcomplete'] = 'Deprovisionuser cron-job complete';
-$string['cronjobwasrunning'] = 'The tool_deprovisionuser cron-job was running. No user was suspended or deleted.';
-$string['subpluginsof'] = 'Sub-plugins of deprovisionuser';
+$string['e-mail-noproblem'] = 'No problems occurred in plugin tool_cleanupusers in the last run.';
+$string['cronjobcomplete'] = 'tool_cleanupusers cron job complete';
+$string['cronjobwasrunning'] = 'The tool_cleanupusers cron job was running. No user was suspended or deleted.';
+$string['subpluginsof'] = 'Sub-plugins of tool_cleanupusers';

--- a/renderer.php
+++ b/renderer.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Renderer for the Web interface of tool_deprovisionuser.
+ * Renderer for the Web interface of tool_cleanupusers.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -25,13 +25,13 @@
 defined('MOODLE_INTERNAL') || die;
 
 /**
- * Class of the tool_deprovisionuser renderer.
+ * Class of the tool_cleanupusers renderer.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_deprovisionuser_renderer extends plugin_renderer_base {
+class tool_cleanupusers_renderer extends plugin_renderer_base {
 
     /**
      * Function expects three arrays and renders them to three separate tables.
@@ -65,32 +65,32 @@ class tool_deprovisionuser_renderer extends plugin_renderer_base {
         // Renders the information for each array in a separate html table.
         $output = '';
         if (!empty($renderneverloggedin)) {
-            $output .= $this->render_table_of_users($renderneverloggedin, array(get_string('Neverloggedin', 'tool_deprovisionuser'),
-                get_string('lastaccess', 'tool_deprovisionuser'), get_string('Archived', 'tool_deprovisionuser'),
-                get_string('Willbe', 'tool_deprovisionuser')));
+            $output .= $this->render_table_of_users($renderneverloggedin, array(get_string('Neverloggedin', 'tool_cleanupusers'),
+                get_string('lastaccess', 'tool_cleanupusers'), get_string('Archived', 'tool_cleanupusers'),
+                get_string('Willbe', 'tool_cleanupusers')));
         }
         if (!empty($rendertosuspend)) {
-            $output .= $this->render_table_of_users($rendertosuspend, array(get_string('oldusers', 'tool_deprovisionuser'),
-                get_string('lastaccess', 'tool_deprovisionuser'),
-                get_string('Archived', 'tool_deprovisionuser'), get_string('Willbe', 'tool_deprovisionuser')));
+            $output .= $this->render_table_of_users($rendertosuspend, array(get_string('oldusers', 'tool_cleanupusers'),
+                get_string('lastaccess', 'tool_cleanupusers'),
+                get_string('Archived', 'tool_cleanupusers'), get_string('Willbe', 'tool_cleanupusers')));
         }
         if (!empty($rendertodelete)) {
-            $output .= $this->render_table_of_users($rendertodelete, array(get_string('titletodelete', 'tool_deprovisionuser'),
-                get_string('lastaccess', 'tool_deprovisionuser'),
-                get_string('Archived', 'tool_deprovisionuser'), get_string('Willbe', 'tool_deprovisionuser')));
+            $output .= $this->render_table_of_users($rendertodelete, array(get_string('titletodelete', 'tool_cleanupusers'),
+                get_string('lastaccess', 'tool_cleanupusers'),
+                get_string('Archived', 'tool_cleanupusers'), get_string('Willbe', 'tool_cleanupusers')));
         }
 
         return $output;
     }
 
     /**
-     * Functions returns the heading for the tool_deprovisionuser.
+     * Functions returns the heading for the tool_cleanupusers.
      *
      * @return string
      */
     public function get_heading() {
         $output = '';
-        $output .= $this->heading(get_string('plugintitel', 'tool_deprovisionuser'));
+        $output .= $this->heading(get_string('plugintitel', 'tool_cleanupusers'));
         return $output;
     }
 
@@ -109,16 +109,16 @@ class tool_deprovisionuser_renderer extends plugin_renderer_base {
             if (!empty($user)) {
                 $userinformation['username'] = $user->username;
                 $userinformation['lastaccess'] = date('d.m.Y h:i:s', $user->lastaccess);
-                $isarchivid = $DB->get_records('tool_deprovisionuser', array('id' => $user->id, 'archived' => 1));
+                $isarchivid = $DB->get_records('tool_cleanupusers', array('id' => $user->id, 'archived' => 1));
                 if (empty($isarchivid)) {
-                    $userinformation['archived'] = get_string('No', 'tool_deprovisionuser');
+                    $userinformation['archived'] = get_string('No', 'tool_cleanupusers');
                 } else {
-                    $userinformation['archived'] = get_string('Yes', 'tool_deprovisionuser');
+                    $userinformation['archived'] = get_string('Yes', 'tool_cleanupusers');
                 }
-                $userinformation['Willbe'] = get_string('shouldbedelted', 'tool_deprovisionuser');
-                $url = new moodle_url('/admin/tool/deprovisionuser/handleuser.php', array('userid' => $user->id, 'action' => 'delete'));
+                $userinformation['Willbe'] = get_string('shouldbedelted', 'tool_cleanupusers');
+                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', array('userid' => $user->id, 'action' => 'delete'));
                 $userinformation['link'] = \html_writer::link($url, \html_writer::img($OUTPUT->pix_url('t/delete'),
-                    get_string('showuser', 'tool_deprovisionuser'), array('class' => "imggroup-" . $user->id)));
+                    get_string('showuser', 'tool_cleanupusers'), array('class' => "imggroup-" . $user->id)));
             }
             $resultarray[$key] = $userinformation;
         }
@@ -139,19 +139,19 @@ class tool_deprovisionuser_renderer extends plugin_renderer_base {
                 $userinformation['username'] = $user->username;
                 $userinformation['lastaccess'] = date('d.m.Y h:i:s', $user->lastaccess);
 
-                $isarchivid = $DB->get_records('tool_deprovisionuser', array('id' => $user->id, 'archived' => 1));
+                $isarchivid = $DB->get_records('tool_cleanupusers', array('id' => $user->id, 'archived' => 1));
                 if (empty($isarchivid)) {
-                    $userinformation['archived'] = get_string('No', 'tool_deprovisionuser');
+                    $userinformation['archived'] = get_string('No', 'tool_cleanupusers');
                 } else {
-                    $userinformation['archived'] = get_string('Yes', 'tool_deprovisionuser');
+                    $userinformation['archived'] = get_string('Yes', 'tool_cleanupusers');
                 }
 
-                $userinformation['Willbe'] = get_string('willbe_archived', 'tool_deprovisionuser');
+                $userinformation['Willbe'] = get_string('willbe_archived', 'tool_cleanupusers');
 
-                $url = new moodle_url('/admin/tool/deprovisionuser/handleuser.php', array('userid' => $user->id, 'action' => 'suspend'));
+                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', array('userid' => $user->id, 'action' => 'suspend'));
 
                 $userinformation['link'] = \html_writer::link($url, \html_writer::img($OUTPUT->pix_url('t/hide'),
-                    get_string('hideuser', 'tool_deprovisionuser'), array('class' => "imggroup-" . $user->id)));
+                    get_string('hideuser', 'tool_cleanupusers'), array('class' => "imggroup-" . $user->id)));
             }
             $result[$key] = $userinformation;
         }
@@ -170,17 +170,17 @@ class tool_deprovisionuser_renderer extends plugin_renderer_base {
             $userinformation = array();
             if (!empty($user)) {
                 $userinformation['username'] = $user->username;
-                $userinformation['lastaccess'] = get_string('neverlogged', 'tool_deprovisionuser');
-                $isarchivid = $DB->get_records('tool_deprovisionuser', array('id' => $user->id, 'archived' => 1));
+                $userinformation['lastaccess'] = get_string('neverlogged', 'tool_cleanupusers');
+                $isarchivid = $DB->get_records('tool_cleanupusers', array('id' => $user->id, 'archived' => 1));
                 if (empty($isarchivid)) {
-                    $userinformation['archived'] = get_string('No', 'tool_deprovisionuser');
+                    $userinformation['archived'] = get_string('No', 'tool_cleanupusers');
                 } else {
-                    $userinformation['archived'] = get_string('Yes', 'tool_deprovisionuser');
+                    $userinformation['archived'] = get_string('Yes', 'tool_cleanupusers');
                 }
-                $userinformation['Willbe'] = get_string('nothinghappens', 'tool_deprovisionuser');
-                $url = new moodle_url('/admin/tool/deprovisionuser/handleuser.php', array('userid' => $user->id, 'action' => 'delete'));
+                $userinformation['Willbe'] = get_string('nothinghappens', 'tool_cleanupusers');
+                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', array('userid' => $user->id, 'action' => 'delete'));
                 $userinformation['link'] = \html_writer::link($url, \html_writer::img($OUTPUT->pix_url('t/delete'),
-                    get_string('showuser', 'tool_deprovisionuser'), array('class' => "imggroup-" . $user->id)));
+                    get_string('showuser', 'tool_cleanupusers'), array('class' => "imggroup-" . $user->id)));
             }
             $result[$key] = $userinformation;
         }
@@ -196,7 +196,7 @@ class tool_deprovisionuser_renderer extends plugin_renderer_base {
     private function render_table_of_users($users, $tableheadings) {
         $table = new html_table();
         $table->head = $tableheadings;
-        $table->attributes['class'] = 'generaltable admintable deprovisionuser';
+        $table->attributes['class'] = 'generaltable admintable cleanupusers';
         $table->data = array();
         foreach ($users as $key => $user) {
             $table->data[$key] = $user;

--- a/renderer.php
+++ b/renderer.php
@@ -116,7 +116,7 @@ class tool_cleanupusers_renderer extends plugin_renderer_base {
                     $userinformation['archived'] = get_string('Yes', 'tool_cleanupusers');
                 }
                 $userinformation['Willbe'] = get_string('shouldbedelted', 'tool_cleanupusers');
-                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', array('userid' => $user->id, 'action' => 'delete'));
+                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', ['userid' => $user->id, 'action' => 'delete']);
                 $userinformation['link'] = \html_writer::link($url, \html_writer::img($OUTPUT->pix_url('t/delete'),
                     get_string('showuser', 'tool_cleanupusers'), array('class' => "imggroup-" . $user->id)));
             }
@@ -148,7 +148,7 @@ class tool_cleanupusers_renderer extends plugin_renderer_base {
 
                 $userinformation['Willbe'] = get_string('willbe_archived', 'tool_cleanupusers');
 
-                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', array('userid' => $user->id, 'action' => 'suspend'));
+                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', ['userid' => $user->id, 'action' => 'suspend']);
 
                 $userinformation['link'] = \html_writer::link($url, \html_writer::img($OUTPUT->pix_url('t/hide'),
                     get_string('hideuser', 'tool_cleanupusers'), array('class' => "imggroup-" . $user->id)));
@@ -178,7 +178,7 @@ class tool_cleanupusers_renderer extends plugin_renderer_base {
                     $userinformation['archived'] = get_string('Yes', 'tool_cleanupusers');
                 }
                 $userinformation['Willbe'] = get_string('nothinghappens', 'tool_cleanupusers');
-                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', array('userid' => $user->id, 'action' => 'delete'));
+                $url = new moodle_url('/admin/tool/cleanupusers/handleuser.php', ['userid' => $user->id, 'action' => 'delete']);
                 $userinformation['link'] = \html_writer::link($url, \html_writer::img($OUTPUT->pix_url('t/delete'),
                     get_string('showuser', 'tool_cleanupusers'), array('class' => "imggroup-" . $user->id)));
             }

--- a/settings.php
+++ b/settings.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Adds tool_deprovisionuser link in admin tree
+ * Adds tool_cleanupusers link in admin tree
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -25,13 +25,13 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
-    $url = $CFG->wwwroot . '/' . $CFG->admin . '/tool/deprovisionuser/index.php';
-    $ADMIN->add('users', new admin_externalpage('deprovisionuser',
-        get_string('plugintitel', 'tool_deprovisionuser'),
-        "$CFG->wwwroot/$CFG->admin/tool/deprovisionuser/index.php"
+    $url = $CFG->wwwroot . '/' . $CFG->admin . '/tool/cleanupusers/index.php';
+    $ADMIN->add('users', new admin_externalpage('cleanupusers',
+        get_string('plugintitel', 'tool_cleanupusers'),
+        "$CFG->wwwroot/$CFG->admin/tool/cleanupusers/index.php"
     ));
     // Adds an entry for every sub-plugin with an settings.php.
-    $ADMIN->add('users', new admin_category('subplugins', get_string('subpluginsof', 'tool_deprovisionuser')));
+    $ADMIN->add('users', new admin_category('subplugins', get_string('subpluginsof', 'tool_cleanupusers')));
     foreach (core_plugin_manager::instance()->get_plugins_of_type('userstatus') as $plugin) {
         global $CFG;
         $plugin->load_settings($ADMIN, 'subplugins', $hassiteconfig);

--- a/styles.css
+++ b/styles.css
@@ -1,20 +1,20 @@
-.deprovisionuser .c0 {
+.cleanupusers .c0 {
     max-width: 200px;
     width: 190px;
 }
-.deprovisionuser .c1 {
+.cleanupusers .c1 {
     max-width: 200px;
     width: 280px;
 }
-.deprovisionuser .c2 {
+.cleanupusers .c2 {
     max-width: 200px;
     width: 150px;
 }
-.deprovisionuser .c3 {
+.cleanupusers .c3 {
     max-width: 200px;
     width: 240px;
 }
-.deprovisionuser .c4 {
+.cleanupusers .c4 {
     max-width: 200px;
     width: 60px;
 }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Data Generator for the tool_deprovisionuser plugin.
+ * Data Generator for the tool_cleanupusers plugin.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @category   test
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -26,16 +26,16 @@
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Data Generator class for the tool_deprovisionuser plugin.
+ * Data Generator class for the tool_cleanupusers plugin.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @category   test
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_deprovisionuser_generator extends testing_data_generator {
+class tool_cleanupusers_generator extends testing_data_generator {
     /**
-     * Creates User to test the tool_deprovisionuser plugin.
+     * Creates User to test the tool_cleanupusers plugin.
      */
     public function test_create_preparation () {
         global $DB;
@@ -51,7 +51,7 @@ class tool_deprovisionuser_generator extends testing_data_generator {
         // notsuspendeduser signed in one year ago
         // suspendeduser2 is suspended
         // deleteuser is suspended signed in one year ago
-        // archivedbyplugin has entry in tool_deprovisionuser and deprovisionuser_archive was suspended one year ago.
+        // archivedbyplugin has entry in tool_cleanupusers and cleanupusers_archive was suspended one year ago.
         // reactivatebyplugin wassuspended by plugin (has entry in both tables) however lastaccess is only few hours ago.
 
         $user = $generator->create_user(array('username' => 'user', 'lastaccess' => $mytimestamp, 'suspended' => '0'));
@@ -77,9 +77,9 @@ class tool_deprovisionuser_generator extends testing_data_generator {
 
         // User that was archived by the plugin and will be deleted in cron-job.
         $suspendeduser3 = $generator->create_user(array('username' => 'anonym', 'suspended' => '1', 'firstname' => 'Anonym'));
-        $DB->insert_record_raw('tool_deprovisionuser', array('id' => $suspendeduser3->id, 'archived' => true,
+        $DB->insert_record_raw('tool_cleanupusers', array('id' => $suspendeduser3->id, 'archived' => true,
             'timestamp' => $timestamponeyearago), true, false, true);
-        $DB->insert_record_raw('deprovisionuser_archive', array('id' => $suspendeduser3->id,
+        $DB->insert_record_raw('cleanupusers_archive', array('id' => $suspendeduser3->id,
             'username' => 'archivedbyplugin', 'suspended' => 1, 'lastaccess' => $timestamponeyearago),
             true, false, true);
         $data['archivedbyplugin'] = $suspendeduser3;
@@ -87,18 +87,18 @@ class tool_deprovisionuser_generator extends testing_data_generator {
         $timestampshortago = $mytimestamp - 3456;
         // User that was archived by the plugin and will be reactivated in cron-job.
         $reactivatebyplugin = $generator->create_user(array('username' => 'anonym2', 'suspended' => '1', 'firstname' => 'Anonym'));
-        $DB->insert_record_raw('tool_deprovisionuser', array('id' => $reactivatebyplugin->id, 'archived' => true,
+        $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivatebyplugin->id, 'archived' => true,
             'timestamp' => $timestampshortago), true, false, true);
-        $DB->insert_record_raw('deprovisionuser_archive', array('id' => $reactivatebyplugin->id,
+        $DB->insert_record_raw('cleanupusers_archive', array('id' => $reactivatebyplugin->id,
             'username' => 'reactivatebyplugin',
             'suspended' => 1, 'lastaccess' => $mytimestamp), true, false, true);
         $data['reactivatebyplugin'] = $reactivatebyplugin;
 
         // User that was archived by the plugin and will be reactivated in cron-job has as firstname Anonym.
         $reactivatebypluginexception = $generator->create_user(array('username' => 'moreanonym', 'suspended' => '1', 'firstname' => 'Anonym'));
-        $DB->insert_record_raw('tool_deprovisionuser', array('id' => $reactivatebypluginexception->id, 'archived' => true,
+        $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivatebypluginexception->id, 'archived' => true,
             'timestamp' => $timestampshortago), true, false, true);
-        $DB->insert_record_raw('deprovisionuser_archive', array('id' => $reactivatebypluginexception->id,
+        $DB->insert_record_raw('cleanupusers_archive', array('id' => $reactivatebypluginexception->id,
             'username' => 'reactivatebypluginexception', 'firstname' => 'Anonym',
             'suspended' => 1, 'lastaccess' => $mytimestamp), true, false, true);
         $data['reactivatebypluginexception'] = $reactivatebypluginexception;

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -51,7 +51,7 @@ class tool_cleanupusers_generator extends testing_data_generator {
         // notsuspendeduser signed in one year ago
         // suspendeduser2 is suspended
         // deleteuser is suspended signed in one year ago
-        // archivedbyplugin has entry in tool_cleanupusers and cleanupusers_archive was suspended one year ago.
+        // archivedbyplugin has entry in tool_cleanupusers and tool_cleanupusers_archive was suspended one year ago.
         // reactivatebyplugin wassuspended by plugin (has entry in both tables) however lastaccess is only few hours ago.
 
         $user = $generator->create_user(array('username' => 'user', 'lastaccess' => $mytimestamp, 'suspended' => '0'));
@@ -79,7 +79,7 @@ class tool_cleanupusers_generator extends testing_data_generator {
         $suspendeduser3 = $generator->create_user(array('username' => 'anonym', 'suspended' => '1', 'firstname' => 'Anonym'));
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $suspendeduser3->id, 'archived' => true,
             'timestamp' => $timestamponeyearago), true, false, true);
-        $DB->insert_record_raw('cleanupusers_archive', array('id' => $suspendeduser3->id,
+        $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $suspendeduser3->id,
             'username' => 'archivedbyplugin', 'suspended' => 1, 'lastaccess' => $timestamponeyearago),
             true, false, true);
         $data['archivedbyplugin'] = $suspendeduser3;
@@ -89,7 +89,7 @@ class tool_cleanupusers_generator extends testing_data_generator {
         $reactivatebyplugin = $generator->create_user(array('username' => 'anonym2', 'suspended' => '1', 'firstname' => 'Anonym'));
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivatebyplugin->id, 'archived' => true,
             'timestamp' => $timestampshortago), true, false, true);
-        $DB->insert_record_raw('cleanupusers_archive', array('id' => $reactivatebyplugin->id,
+        $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $reactivatebyplugin->id,
             'username' => 'reactivatebyplugin',
             'suspended' => 1, 'lastaccess' => $mytimestamp), true, false, true);
         $data['reactivatebyplugin'] = $reactivatebyplugin;
@@ -98,7 +98,7 @@ class tool_cleanupusers_generator extends testing_data_generator {
         $reactivatebypluginexception = $generator->create_user(array('username' => 'moreanonym', 'suspended' => '1', 'firstname' => 'Anonym'));
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivatebypluginexception->id, 'archived' => true,
             'timestamp' => $timestampshortago), true, false, true);
-        $DB->insert_record_raw('cleanupusers_archive', array('id' => $reactivatebypluginexception->id,
+        $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $reactivatebypluginexception->id,
             'username' => 'reactivatebypluginexception', 'firstname' => 'Anonym',
             'suspended' => 1, 'lastaccess' => $mytimestamp), true, false, true);
         $data['reactivatebypluginexception'] = $reactivatebypluginexception;

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -95,7 +95,8 @@ class tool_cleanupusers_generator extends testing_data_generator {
         $data['reactivatebyplugin'] = $reactivatebyplugin;
 
         // User that was archived by the plugin and will be reactivated in cron-job has as firstname Anonym.
-        $reactivatebypluginexception = $generator->create_user(array('username' => 'moreanonym', 'suspended' => '1', 'firstname' => 'Anonym'));
+        $reactivatebypluginexception = $generator->create_user(['username' => 'moreanonym', 'suspended' => '1',
+            'firstname' => 'Anonym']);
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivatebypluginexception->id, 'archived' => true,
             'timestamp' => $timestampshortago), true, false, true);
         $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $reactivatebypluginexception->id,

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -16,7 +16,7 @@
 /**
  * PHPUnit data generator tests
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @category   phpunit
  * @copyright  2016/17 Nina Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -28,12 +28,12 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * PHPUnit data class generator testcase
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @category   phpunit
  * @copyright  2016/17 Nina Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_deprovisionuser_generator_testcase extends advanced_testcase {
+class tool_cleanupusers_generator_testcase extends advanced_testcase {
     public function test_generator() {
         $this->resetAfterTest(true);
     }

--- a/tests/tool_cleanupusers_test.php
+++ b/tests/tool_cleanupusers_test.php
@@ -15,30 +15,30 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Test script for the moodle tool_deprovisionuser plugin.
+ * Test script for the moodle tool_cleanupusers plugin.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 defined('MOODLE_INTERNAL') || die();
 
-use tool_deprovisionuser\task;
+use tool_cleanupusers\task;
 
 
 /**
- * Testcase class for executing phpunit test for the moodle tool_deprovisionuser plugin.
+ * Testcase class for executing phpunit test for the moodle tool_cleanupusers plugin.
  *
- * @package    tool_deprovisionuser
+ * @package    tool_cleanupusers
  * @copyright  2016/17 N Herrmann
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_deprovisionuser_testcase extends advanced_testcase {
+class tool_cleanupusers_testcase extends advanced_testcase {
 
     protected function set_up() {
         // Recommended in Moodle docs to always include CFG.
         global $CFG;
-        $generator = $this->getDataGenerator()->get_plugin_generator('tool_deprovisionuser');
+        $generator = $this->getDataGenerator()->get_plugin_generator('tool_cleanupusers');
         $data = $generator->test_create_preparation();
         $this->resetAfterTest(true);
         return $data;
@@ -47,20 +47,20 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
     /**
      * Function to test the the archiveduser class.
      *
-     * @see \tool_deprovisionuser\archiveduser
+     * @see \tool_cleanupusers\archiveduser
      */
     public function test_archiveduser() {
         global $DB;
         $data = $this->set_up();
         $this->assertNotEmpty($data);
 
-        // Users that are archived will be marked as suspended in the user table and in the tool_deprovisionuser table.
+        // Users that are archived will be marked as suspended in the user table and in the tool_cleanupusers table.
         // Additionally they will be anomynised in the user table. Firstname will be Anonym, Username anonym + id.
         // User is not suspended and did sign in.
-        $neutraltosuspended = new \tool_deprovisionuser\archiveduser($data['user']->id, 0,
+        $neutraltosuspended = new \tool_cleanupusers\archiveduser($data['user']->id, 0,
             $data['user']->lastaccess, $data['user']->username, $data['user']->deleted);
         $neutraltosuspended->archive_me();
-        $recordtooltable = $DB->get_record('tool_deprovisionuser', array('id' => $data['user']->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $data['user']->id));
         $recordusertable = $DB->get_record('user', array('id' => $data['user']->id));
         $this->assertEquals(1, $recordusertable->suspended);
         $this->assertEquals(1, $recordtooltable->archived);
@@ -69,41 +69,41 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
 
         // Users that are activated will be marked as suspended=0 in the user table.
         // suspendeduser is only flagged as suspended in the user table
-        $neutraltosuspended = new \tool_deprovisionuser\archiveduser($data['suspendeduser']->id, $data['suspendeduser']->suspended,
+        $neutraltosuspended = new \tool_cleanupusers\archiveduser($data['suspendeduser']->id, $data['suspendeduser']->suspended,
             $data['suspendeduser']->lastaccess, $data['suspendeduser']->username, $data['suspendeduser']->deleted);
         $neutraltosuspended->activate_me();
-        $recordtooltable = $DB->get_record('tool_deprovisionuser', array('id' => $data['suspendeduser']->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $data['suspendeduser']->id));
         $recordusertable = $DB->get_record('user', array('id' => $data['suspendeduser']->id));
         $this->assertEquals(0, $recordusertable->suspended);
         $this->assertEmpty($recordtooltable);
 
         // Users that are deleted will be marked as deleted in the user table.
-        // The entry the tool_deprovisionuser table will be deleted.
+        // The entry the tool_cleanupusers table will be deleted.
         // Suspenduser2 is marked as suspended in the user table no additional information.
-        $suspendedtodelete = new \tool_deprovisionuser\archiveduser($data['suspendeduser2']->id, 0,
+        $suspendedtodelete = new \tool_cleanupusers\archiveduser($data['suspendeduser2']->id, 0,
             $data['suspendeduser2']->lastaccess, $data['suspendeduser2']->username, $data['suspendeduser2']->deleted);
         $suspendedtodelete->delete_me();
-        $recordtooltable = $DB->get_record('tool_deprovisionuser', array('id' => $data['suspendeduser2']->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $data['suspendeduser2']->id));
         $recordusertable = $DB->get_record('user', array('id' => $data['suspendeduser2']->id));
         $this->assertEquals(1, $recordusertable->deleted);
         $this->assertNotEmpty($recordusertable);
         $this->assertEmpty($recordtooltable);
 
         // Users that are activated will be marked as active in the user table.
-        // The entry the tool_deprovisionuser table will be deleted.
-        // archivedbyplugin has entry in tool_deprovisionuser and deprovisionuser_archive was suspended one year ago.
-        $suspendedtoactive = new \tool_deprovisionuser\archiveduser($data['archivedbyplugin']->id, $data['archivedbyplugin']->suspended,
+        // The entry the tool_cleanupusers table will be deleted.
+        // archivedbyplugin has entry in tool_cleanupusers and cleanupusers_archive was suspended one year ago.
+        $suspendedtoactive = new \tool_cleanupusers\archiveduser($data['archivedbyplugin']->id, $data['archivedbyplugin']->suspended,
             $data['archivedbyplugin']->lastaccess, $data['archivedbyplugin']->username, $data['archivedbyplugin']->deleted);
         $suspendedtoactive->activate_me();
-        $recordtooltable = $DB->get_record('tool_deprovisionuser', array('id' => $data['archivedbyplugin']->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $data['archivedbyplugin']->id));
         $recordusertable = $DB->get_record('user', array('id' => $data['archivedbyplugin']->id));
         $this->assertEquals(0, $recordusertable->suspended);
         $this->assertEmpty($recordtooltable);
 
-        $useraccount = new \tool_deprovisionuser\archiveduser($data['reactivatebyplugin']->id, 0,
+        $useraccount = new \tool_cleanupusers\archiveduser($data['reactivatebyplugin']->id, 0,
             $data['reactivatebyplugin']->lastaccess, $data['reactivatebyplugin']->username, $data['reactivatebyplugin']->deleted);
         $useraccount->activate_me();
-        $recordtooltable = $DB->get_record('tool_deprovisionuser', array('id' => $data['reactivatebyplugin']->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $data['reactivatebyplugin']->id));
         $recordusertable = $DB->get_record('user', array('id' => $data['reactivatebyplugin']->id));
         $this->assertEquals(0, $recordusertable->suspended);
         $this->assertEmpty($recordtooltable);
@@ -115,39 +115,39 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
         $data = $this->set_up();
         $this->assertNotEmpty($data);
 
-        $useraccount = new \tool_deprovisionuser\archiveduser($data['reactivatebypluginexception']->id, $data['reactivatebypluginexception']->suspended,
+        $useraccount = new \tool_cleanupusers\archiveduser($data['reactivatebypluginexception']->id, $data['reactivatebypluginexception']->suspended,
             $data['reactivatebypluginexception']->lastaccess, $data['reactivatebypluginexception']->username,
             $data['reactivatebypluginexception']->deleted);
-        $this->expectException('tool_deprovisionuser\deprovisionuser_exception');
+        $this->expectException('tool_cleanupusers\cleanupusers_exception');
         $this->expectExceptionMessage('Not able to activate user.');
         $useraccount->activate_me();
 
-        // When entry in deprovisionuser_archive table is deleted user can not be updated.
-        $useraccount = new \tool_deprovisionuser\archiveduser($data['reactivatebyplugin']->id, $data['reactivatebyplugin']->suspended,
+        // When entry in cleanupusers_archive table is deleted user can not be updated.
+        $useraccount = new \tool_cleanupusers\archiveduser($data['reactivatebyplugin']->id, $data['reactivatebyplugin']->suspended,
             $data['reactivatebyplugin']->lastaccess, $data['reactivatebyplugin']->username,
             $data['reactivatebyplugin']->deleted);
-        $DB->delete_records('deprovisionuser_archive', array('id' => $data['reactivatebyplugin']->id));
-        $this->expectException('tool_deprovisionuser\deprovisionuser_exception');
+        $DB->delete_records('cleanupusers_archive', array('id' => $data['reactivatebyplugin']->id));
+        $this->expectException('tool_cleanupusers\cleanupusers_exception');
         $this->expectExceptionMessage('Not able to activate user.');
         $useraccount->activate_me();
 
         // Admin Users will not be deleted neither archived.
         $this->setAdminUser();
-        $adminaccount = new \tool_deprovisionuser\archiveduser($USER->id, $USER->suspended,
+        $adminaccount = new \tool_cleanupusers\archiveduser($USER->id, $USER->suspended,
             $USER->lastaccess, $USER->username, $USER->deleted);
-        $this->expectException('tool_deprovisionuser\deprovisionuser_exception');
+        $this->expectException('tool_cleanupusers\cleanupusers_exception');
         $this->expectExceptionMessage('Not able to suspend user');
         $adminaccount->archive_me();
-        $recordtooltable = $DB->get_record('moodle_deprovisionuser', array('id' => $USER->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $USER->id));
         $this->assertEmpty($recordtooltable);
 
         $this->setAdminUser();
-        $adminaccount = new \tool_deprovisionuser\archiveduser($USER->id, 0,
+        $adminaccount = new \tool_cleanupusers\archiveduser($USER->id, 0,
             $USER->lastaccess, $USER->username, $USER->deleted);
-        $this->expectException('tool_deprovisionuser\deprovisionuser_exception');
+        $this->expectException('tool_cleanupusers\cleanupusers_exception');
         $this->expectExceptionMessage('Not able to delete user');
         $adminaccount->delete_me();
-        $recordtooltable = $DB->get_record('tool_deprovisionuser', array($USER->id));
+        $recordtooltable = $DB->get_record('tool_cleanupusers', array($USER->id));
         $this->assertEmpty($recordtooltable);
         $this->resetAfterTest(true);
     }
@@ -165,9 +165,9 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
         unset_config('noemailever');
         $sink = $this->redirectEmails();
 
-        $cronjob = new tool_deprovisionuser\task\archive_user_task();
+        $cronjob = new tool_cleanupusers\task\archive_user_task();
         $name = $cronjob->get_name();
-        $this->assertEquals(get_string('archive_user_task', 'tool_deprovisionuser'), $name);
+        $this->assertEquals(get_string('archive_user_task', 'tool_cleanupusers'), $name);
 
         // Before cron-job is executed users are not suspended.
         $recordusertable = $DB->get_record('user', array('id' => $data['user']->id));
@@ -177,8 +177,8 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
         $this->assertEquals(0, $recordusertable->suspended);
 
         // Run cron-job with timechecker plugin.
-        set_config('deprovisionuser_subplugin', 'timechecker', 'tool_deprovisionuser');
-        $cronjob = new tool_deprovisionuser\task\archive_user_task();
+        set_config('cleanupusers_subplugin', 'timechecker', 'tool_cleanupusers');
+        $cronjob = new tool_cleanupusers\task\archive_user_task();
         $cronjob->execute();
 
         // Administrator should have received an email.
@@ -233,7 +233,7 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
     /**
      * Test the the deprovisionuser cron-job complete event.
      *
-     * @see \tool_deprovisionuser\event\deprovisionusercronjob_completed
+     * @see \tool_cleanupusers\event\deprovisionusercronjob_completed
      */
     public function test_logging() {
         global $DB;
@@ -260,12 +260,12 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
         // Necessary to get current logs otherwise $DB get_record does not contain the event.
         $manager = get_log_manager(true);
 
-        set_config('deprovisionuser_subplugin', 'timechecker', 'tool_deprovisionuser');
-        $cronjob = new tool_deprovisionuser\task\archive_user_task();
+        set_config('cleanupusers_subplugin', 'timechecker', 'tool_cleanupusers');
+        $cronjob = new tool_cleanupusers\task\archive_user_task();
         $cronjob->execute();
 
         $logstore = $DB->get_record_select('logstore_standard_log', 'timecreated >=' . $timestamp .
-            'AND eventname = \'\tool_deprovisionuser\event\deprovisionusercronjob_completed\'');
+            'AND eventname = \'\tool_cleanupusers\event\deprovisionusercronjob_completed\'');
         $this->assertEquals('a:2:{s:15:"numbersuspended";i:1;s:13:"numberdeleted";i:2;}', $logstore->other);
 
         $this->resetAfterTest();
@@ -274,14 +274,14 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
     /**
      * Test the the sub-plugin_select_form.
      *
-     * @see \tool_deprovisionuser\subplugin_select_form
+     * @see \tool_cleanupusers\subplugin_select_form
      */
     public function test_subpluginform() {
         $data = $this->set_up();
         $this->assertNotEmpty($data);
 
         // Validation with existing sub-plugin returns true.
-        $subpluginform = new tool_deprovisionuser\subplugin_select_form();
+        $subpluginform = new tool_cleanupusers\subplugin_select_form();
         $validationdata = array ("subplugin" => 'timechecker');
         $return = $subpluginform->validation($validationdata, null);
         $this->assertEquals(true, $return);
@@ -289,8 +289,8 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
         // Validation with non-existing sub-plugin returns an array with an errormessage.
         $validationdata = array ("subplugin" => 'nosubplugin');
         $return = $subpluginform->validation($validationdata, null);
-        $errorarray = array('subplugin' => new tool_deprovisionuser\deprovisionuser_subplugin_exception
-            (get_string('errormessagesubplugin', 'tool_deprovisionuser')));
+        $errorarray = array('subplugin' => new tool_cleanupusers\cleanupusers_subplugin_exception
+            (get_string('errormessagesubplugin', 'tool_cleanupusers')));
         $this->assertEquals($errorarray, $return);
         $this->resetAfterTest(true);
 
@@ -303,9 +303,9 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
         global $DB;
         $this->resetAfterTest(true);
         $DB->delete_records('user');
-        $DB->delete_records('tool_deprovisionuser');
+        $DB->delete_records('tool_cleanupusers');
         $this->assertEmpty($DB->get_records('user'));
-        $this->assertEmpty($DB->get_records('tool_deprovisionuser'));
+        $this->assertEmpty($DB->get_records('tool_cleanupusers'));
     }
 
     /**
@@ -314,6 +314,6 @@ class tool_deprovisionuser_testcase extends advanced_testcase {
     public function test_user_table_was_reset() {
         global $DB;
         $this->assertEquals(2, $DB->count_records('user', array()));
-        $this->assertEquals(0, $DB->count_records('tool_deprovisionuser', array()));
+        $this->assertEquals(0, $DB->count_records('tool_cleanupusers', array()));
     }
 }

--- a/tests/tool_cleanupusers_test.php
+++ b/tests/tool_cleanupusers_test.php
@@ -68,7 +68,7 @@ class tool_cleanupusers_testcase extends advanced_testcase {
         $this->assertEquals('anonym' . $data['user']->id, $recordusertable->username);
 
         // Users that are activated will be marked as suspended=0 in the user table.
-        // suspendeduser is only flagged as suspended in the user table
+        // suspendeduser is only flagged as suspended in the user table.
         $neutraltosuspended = new \tool_cleanupusers\archiveduser($data['suspendeduser']->id, $data['suspendeduser']->suspended,
             $data['suspendeduser']->lastaccess, $data['suspendeduser']->username, $data['suspendeduser']->deleted);
         $neutraltosuspended->activate_me();
@@ -92,8 +92,9 @@ class tool_cleanupusers_testcase extends advanced_testcase {
         // Users that are activated will be marked as active in the user table.
         // The entry the tool_cleanupusers table will be deleted.
         // archivedbyplugin has entry in tool_cleanupusers and tool_cleanupusers_archive was suspended one year ago.
-        $suspendedtoactive = new \tool_cleanupusers\archiveduser($data['archivedbyplugin']->id, $data['archivedbyplugin']->suspended,
-            $data['archivedbyplugin']->lastaccess, $data['archivedbyplugin']->username, $data['archivedbyplugin']->deleted);
+        $suspendedtoactive = new \tool_cleanupusers\archiveduser($data['archivedbyplugin']->id,
+            $data['archivedbyplugin']->suspended, $data['archivedbyplugin']->lastaccess, $data['archivedbyplugin']->username,
+            $data['archivedbyplugin']->deleted);
         $suspendedtoactive->activate_me();
         $recordtooltable = $DB->get_record('tool_cleanupusers', array('id' => $data['archivedbyplugin']->id));
         $recordusertable = $DB->get_record('user', array('id' => $data['archivedbyplugin']->id));
@@ -115,9 +116,9 @@ class tool_cleanupusers_testcase extends advanced_testcase {
         $data = $this->set_up();
         $this->assertNotEmpty($data);
 
-        $useraccount = new \tool_cleanupusers\archiveduser($data['reactivatebypluginexception']->id, $data['reactivatebypluginexception']->suspended,
-            $data['reactivatebypluginexception']->lastaccess, $data['reactivatebypluginexception']->username,
-            $data['reactivatebypluginexception']->deleted);
+        $useraccount = new \tool_cleanupusers\archiveduser($data['reactivatebypluginexception']->id,
+            $data['reactivatebypluginexception']->suspended, $data['reactivatebypluginexception']->lastaccess,
+            $data['reactivatebypluginexception']->username, $data['reactivatebypluginexception']->deleted);
         $this->expectException('tool_cleanupusers\cleanupusers_exception');
         $this->expectExceptionMessage('Not able to activate user.');
         $useraccount->activate_me();

--- a/tests/tool_cleanupusers_test.php
+++ b/tests/tool_cleanupusers_test.php
@@ -264,8 +264,8 @@ class tool_cleanupusers_testcase extends advanced_testcase {
         $cronjob = new tool_cleanupusers\task\archive_user_task();
         $cronjob->execute();
 
-        $logstore = $DB->get_record_select('logstore_standard_log', 'timecreated >=' . $timestamp .
-            'AND eventname = \'\tool_cleanupusers\event\deprovisionusercronjob_completed\'');
+        $logstore = $DB->get_record_select('logstore_standard_log', 'timecreated >= ? ' .
+            'AND eventname = \'\tool_cleanupusers\event\deprovisionusercronjob_completed\'', [$timestamp]);
         $this->assertEquals('a:2:{s:15:"numbersuspended";i:1;s:13:"numberdeleted";i:2;}', $logstore->other);
 
         $this->resetAfterTest();

--- a/tests/tool_cleanupusers_test.php
+++ b/tests/tool_cleanupusers_test.php
@@ -91,7 +91,7 @@ class tool_cleanupusers_testcase extends advanced_testcase {
 
         // Users that are activated will be marked as active in the user table.
         // The entry the tool_cleanupusers table will be deleted.
-        // archivedbyplugin has entry in tool_cleanupusers and cleanupusers_archive was suspended one year ago.
+        // archivedbyplugin has entry in tool_cleanupusers and tool_cleanupusers_archive was suspended one year ago.
         $suspendedtoactive = new \tool_cleanupusers\archiveduser($data['archivedbyplugin']->id, $data['archivedbyplugin']->suspended,
             $data['archivedbyplugin']->lastaccess, $data['archivedbyplugin']->username, $data['archivedbyplugin']->deleted);
         $suspendedtoactive->activate_me();
@@ -122,11 +122,11 @@ class tool_cleanupusers_testcase extends advanced_testcase {
         $this->expectExceptionMessage('Not able to activate user.');
         $useraccount->activate_me();
 
-        // When entry in cleanupusers_archive table is deleted user can not be updated.
+        // When entry in tool_cleanupusers_archive table is deleted user can not be updated.
         $useraccount = new \tool_cleanupusers\archiveduser($data['reactivatebyplugin']->id, $data['reactivatebyplugin']->suspended,
             $data['reactivatebyplugin']->lastaccess, $data['reactivatebyplugin']->username,
             $data['reactivatebyplugin']->deleted);
-        $DB->delete_records('cleanupusers_archive', array('id' => $data['reactivatebyplugin']->id));
+        $DB->delete_records('tool_cleanupusers_archive', array('id' => $data['reactivatebyplugin']->id));
         $this->expectException('tool_cleanupusers\cleanupusers_exception');
         $this->expectExceptionMessage('Not able to activate user.');
         $useraccount->activate_me();

--- a/userstatus/timechecker/classes/timechecker.php
+++ b/userstatus/timechecker/classes/timechecker.php
@@ -106,7 +106,7 @@ class timechecker implements userstatusinterface {
      * All users who should be deleted will be returned in the array.
      * The array includes merely the necessary information which comprises the userid, lastaccess, suspended, deleted
      * and the username.
-     * The function checks the user table and the cleanupusers_archive table. Therefore users who are suspended by
+     * The function checks the user table and the tool_cleanupusers_archive table. Therefore users who are suspended by
      * the tool_cleanupusers plugin and users who are suspended manually are screened.
      *
      * @return array of users who should be deleted.
@@ -153,7 +153,7 @@ class timechecker implements userstatusinterface {
                     if ($suspendedbyplugin) {
                         // Users who are suspended by the plugin, therefore the plugin table is used.
                         $select = 'id=' . $user->id;
-                        $pluginuser = $DB->get_record_select('cleanupusers_archive', $select);
+                        $pluginuser = $DB->get_record_select('tool_cleanupusers_archive', $select);
                         $informationuser = new archiveduser($pluginuser->id, $pluginuser->suspended,
                             $pluginuser->lastaccess, $pluginuser->username, $pluginuser->deleted);
                     } else {
@@ -189,12 +189,12 @@ class timechecker implements userstatusinterface {
                 $mytimestamp = time();
 
                 // There is no entry in the shadow table, user that is supposed to be reactivated was archived manually.
-                if (empty($DB->get_record('cleanupusers_archive', array('id' => $user->id)))) {
+                if (empty($DB->get_record('tool_cleanupusers_archive', array('id' => $user->id)))) {
                     $timenotloggedin = $mytimestamp - $user->lastaccess;
                     $activateuser = new archiveduser($user->id, $user->suspended, $user->lastaccess, $user->username,
                         $user->deleted);
                 } else {
-                    $shadowtableuser = $DB->get_record('cleanupusers_archive', array('id' => $user->id));
+                    $shadowtableuser = $DB->get_record('tool_cleanupusers_archive', array('id' => $user->id));
                     // There is an entry in the shadowtable, data from the shadowtable is used.
                     if ($shadowtableuser->lastaccess !== 0) {
                         $timenotloggedin = $mytimestamp - $shadowtableuser->lastaccess;

--- a/userstatus/timechecker/lang/en/userstatus_timechecker.php
+++ b/userstatus/timechecker/lang/en/userstatus_timechecker.php
@@ -16,7 +16,7 @@
 /**
  * This file contains language strings used in the timechecker sub-plugin.
  *
- * @package deprovisionuser_userstatus_timechecker
+ * @package userstatus_timechecker
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/userstatus/timechecker/settings.php
+++ b/userstatus/timechecker/settings.php
@@ -16,21 +16,21 @@
 
 /**
  * Settings.php
- * @package deprovisionuser_userstatus_timechecker
+ * @package userstatus_timechecker
  * @copyright 2016/17 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-// Included in admin/tool/deprovisionuser/classes/plugininfo/userstatus.php therefore need to include global variable.
+// Included in admin/tool/cleanupusers/classes/plugininfo/userstatus.php therefore need to include global variable.
 global $CFG, $PAGE;
 
 $PAGE->set_title(get_string('pluginname', 'userstatus_timechecker'));
 $PAGE->set_heading(get_string('pluginname', 'userstatus_timechecker'));
 
 if ($hassiteconfig) {
-    $url = $CFG->wwwroot . '/' . $CFG->admin . '/tool/deprovisionuser/timechecker/index.php';
+    $url = $CFG->wwwroot . '/' . $CFG->admin . '/tool/cleanupusers/timechecker/index.php';
     $settings->add(new admin_setting_heading('timechecker_heading', get_string('settingsinformation',
         'userstatus_timechecker'), get_string('introsettingstext', 'userstatus_timechecker')));
     $settings->add(new admin_setting_configtext('userstatus_timechecker/suspendtime',

--- a/userstatus/timechecker/tests/generator/lib.php
+++ b/userstatus/timechecker/tests/generator/lib.php
@@ -69,7 +69,7 @@ class userstatus_timechecker_generator extends testing_data_generator {
         $tendaysago = $mytimestamp - 864000;
         $reactivate = $generator->create_user(array('username' => 'Anonym', 'suspended' => 1));
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivate->id, 'archived' => true), true, false, true);
-        $DB->insert_record_raw('cleanupusers_archive', array('id' => $reactivate->id, 'username' => 'reactivate',
+        $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $reactivate->id, 'username' => 'reactivate',
             'suspended' => 1, 'lastaccess' => $tendaysago), true, false, true);
         $data['reactivate'] = $reactivate;
 

--- a/userstatus/timechecker/tests/generator/lib.php
+++ b/userstatus/timechecker/tests/generator/lib.php
@@ -68,8 +68,8 @@ class userstatus_timechecker_generator extends testing_data_generator {
         // User suspended by the plugin.
         $tendaysago = $mytimestamp - 864000;
         $reactivate = $generator->create_user(array('username' => 'Anonym', 'suspended' => 1));
-        $DB->insert_record_raw('tool_deprovisionuser', array('id' => $reactivate->id, 'archived' => true), true, false, true);
-        $DB->insert_record_raw('deprovisionuser_archive', array('id' => $reactivate->id, 'username' => 'reactivate',
+        $DB->insert_record_raw('tool_cleanupusers', array('id' => $reactivate->id, 'archived' => true), true, false, true);
+        $DB->insert_record_raw('cleanupusers_archive', array('id' => $reactivate->id, 'username' => 'reactivate',
             'suspended' => 1, 'lastaccess' => $tendaysago), true, false, true);
         $data['reactivate'] = $reactivate;
 

--- a/userstatus/timechecker/tests/userstatus_timechecker_test.php
+++ b/userstatus/timechecker/tests/userstatus_timechecker_test.php
@@ -116,9 +116,9 @@ class userstatus_timechecker_testcase extends advanced_testcase {
         global $DB;
         $this->resetAfterTest(true);
         $DB->delete_records('user');
-        $DB->delete_records('tool_deprovisionuser');
+        $DB->delete_records('tool_cleanupusers');
         $this->assertEmpty($DB->get_records('user'));
-        $this->assertEmpty($DB->get_records('tool_deprovisionuser'));
+        $this->assertEmpty($DB->get_records('tool_cleanupusers'));
     }
     /**
      * Methodes recommended by moodle to assure database is reset.
@@ -126,6 +126,6 @@ class userstatus_timechecker_testcase extends advanced_testcase {
     public function test_user_table_was_reset() {
         global $DB;
         $this->assertEquals(2, $DB->count_records('user', array()));
-        $this->assertEquals(0, $DB->count_records('tool_deprovisionuser', array()));
+        $this->assertEquals(0, $DB->count_records('tool_cleanupusers', array()));
     }
 }

--- a/userstatus/timechecker/version.php
+++ b/userstatus/timechecker/version.php
@@ -16,7 +16,7 @@
 
 /**
  * Version details
- * @package deprovisionuser_userstatus_timechecker
+ * @package userstatus_timechecker
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -29,4 +29,4 @@ $plugin->component = 'userstatus_timechecker'; // Full name of the plugin (used 
 $plugin->release = 'v1.0-r0';
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->dependencies = array(
-    'tool_deprovisionuser' => ANY_VERSION);
+    'tool_cleanupusers' => ANY_VERSION);

--- a/userstatus/userstatuswwu/classes/userstatuswwu.php
+++ b/userstatus/userstatuswwu/classes/userstatuswwu.php
@@ -277,7 +277,7 @@ class userstatuswwu implements userstatusinterface {
             if (!empty($moodleuser->timestamp)) {
                 // In case the user was suspended for longer than one year he/she is supposed to be deleted.
                 if ($moodleuser->timestamp < $timestamp - 31622400) {
-                    $user = $DB->get_record('cleanupusers_archive', array('id' => $moodleuser->id));
+                    $user = $DB->get_record('tool_cleanupusers_archive', array('id' => $moodleuser->id));
 
                     $againlisted = in_array($user->username, $this->zivmemberlist);
                     if (!$againlisted) {

--- a/userstatus/userstatuswwu/classes/userstatuswwu.php
+++ b/userstatus/userstatuswwu/classes/userstatuswwu.php
@@ -23,8 +23,8 @@
  */
 namespace userstatus_userstatuswwu;
 
-use tool_deprovisionuser\userstatusinterface;
-use tool_deprovisionuser\archiveduser;
+use tool_cleanupusers\userstatusinterface;
+use tool_cleanupusers\archiveduser;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -246,7 +246,7 @@ class userstatuswwu implements userstatusinterface {
 
         foreach ($users as $moodleuser) {
             // In case the user is a siteadmin or has an entry in the plugin table he/she will not be displayed.
-            if (is_siteadmin($moodleuser) || !empty($DB->get_record('tool_deprovisionuser', array('id' => $moodleuser->id)))) {
+            if (is_siteadmin($moodleuser) || !empty($DB->get_record('tool_cleanupusers', array('id' => $moodleuser->id)))) {
                 continue;
             }
             // Additional check for properties.
@@ -277,7 +277,7 @@ class userstatuswwu implements userstatusinterface {
             if (!empty($moodleuser->timestamp)) {
                 // In case the user was suspended for longer than one year he/she is supposed to be deleted.
                 if ($moodleuser->timestamp < $timestamp - 31622400) {
-                    $user = $DB->get_record('deprovisionuser_archive', array('id' => $moodleuser->id));
+                    $user = $DB->get_record('cleanupusers_archive', array('id' => $moodleuser->id));
 
                     $againlisted = in_array($user->username, $this->zivmemberlist);
                     if (!$againlisted) {
@@ -309,6 +309,6 @@ class userstatuswwu implements userstatusinterface {
      */
     private function get_users_suspended_not_deleted() {
         global $DB;
-        return $DB->get_records('tool_deprovisionuser');
+        return $DB->get_records('tool_cleanupusers');
     }
 }

--- a/userstatus/userstatuswwu/classes/userstatuswwu_exception.php
+++ b/userstatus/userstatuswwu/classes/userstatuswwu_exception.php
@@ -16,7 +16,7 @@
 /**
  * Create an Exception Class for the userstatus_userstatuswwu
  *
- * @package   tool_deprovisionuser
+ * @package   tool_cleanupusers
  * @copyright 2017 N. Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/userstatus/userstatuswwu/lang/en/userstatus_userstatuswwu.php
+++ b/userstatus/userstatuswwu/lang/en/userstatus_userstatuswwu.php
@@ -16,7 +16,7 @@
 /**
  * This file contains language strings used in the userstatuswwu sub-plugin.
  *
- * @package tool_deprovisionuser
+ * @package tool_cleanupusers
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/userstatus/userstatuswwu/settings.php
+++ b/userstatus/userstatuswwu/settings.php
@@ -16,21 +16,21 @@
 
 /**
  * Settings.php
- * @package deprovisionuser_userstatus_userstatuswwu
+ * @package userstatus_userstatuswwu
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-// Included in admin/tool/deprovisionuser/classes/plugininfo/userstatus.php therefore need to include global variable.
+// Included in admin/tool/cleanupusers/classes/plugininfo/userstatus.php therefore need to include global variable.
 global $CFG, $PAGE;
 
 $PAGE->set_title(get_string('pluginname', 'userstatus_userstatuswwu'));
 $PAGE->set_heading(get_string('pluginname', 'userstatus_userstatuswwu'));
 
 if ($hassiteconfig) {
-    $url = $CFG->wwwroot . '/' . $CFG->admin . '/tool/deprovisionuser/userstatus/userstatuswwu/index.php';
+    $url = $CFG->wwwroot . '/' . $CFG->admin . '/tool/cleanupusers/userstatus/userstatuswwu/index.php';
     $settings->add(new admin_setting_heading('userstatus_userstatuswwu/introduction',
         get_string('headingintroduction', 'userstatus_userstatuswwu'),
         get_string('introduction', 'userstatus_userstatuswwu')));

--- a/userstatus/userstatuswwu/tests/generator/lib.php
+++ b/userstatus/userstatuswwu/tests/generator/lib.php
@@ -69,7 +69,7 @@ class userstatus_userstatuswwu_generator extends testing_data_generator {
         $userarchived = $generator->create_user(array('username' => 's_other07', 'lastaccess' => $mytimestamp, 'suspended' => 1));
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $userarchived->id, 'archived' => true,
             'timestamp' => $unixoneyearnintydays), true, false, true);
-        $DB->insert_record_raw('cleanupusers_archive', array('id' => $userarchived->id, 'suspended' => 1,
+        $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $userarchived->id, 'suspended' => 1,
             'deleted' => 0, 'lastaccess' => $unixoneyearnintydays, 'username' => 's_other07'), true,
             false, true);
         $data['s_other07'] = $userarchived;
@@ -87,7 +87,7 @@ class userstatus_userstatuswwu_generator extends testing_data_generator {
             'suspended' => 1, 'firstname' => 'Anonym'));
         $DB->insert_record_raw('tool_cleanupusers', array('id' => $deleteme->id, 'archived' => true,
             'timestamp' => $unixoneyearnintydays), true, false, true);
-        $DB->insert_record_raw('cleanupusers_archive', array('id' => $deleteme->id, 'suspended' => 1,
+        $DB->insert_record_raw('tool_cleanupusers_archive', array('id' => $deleteme->id, 'suspended' => 1,
             'deleted' => 0, 'lastaccess' => $unixoneyearnintydays, 'username' => 'd_me09'), true,
             false, true);
         $data['d_me09'] = $deleteme;

--- a/userstatus/userstatuswwu/tests/generator/lib.php
+++ b/userstatus/userstatuswwu/tests/generator/lib.php
@@ -67,9 +67,9 @@ class userstatus_userstatuswwu_generator extends testing_data_generator {
         $unixoneyearnintydays = $mytimestamp - 39528000;
 
         $userarchived = $generator->create_user(array('username' => 's_other07', 'lastaccess' => $mytimestamp, 'suspended' => 1));
-        $DB->insert_record_raw('tool_deprovisionuser', array('id' => $userarchived->id, 'archived' => true,
+        $DB->insert_record_raw('tool_cleanupusers', array('id' => $userarchived->id, 'archived' => true,
             'timestamp' => $unixoneyearnintydays), true, false, true);
-        $DB->insert_record_raw('deprovisionuser_archive', array('id' => $userarchived->id, 'suspended' => 1,
+        $DB->insert_record_raw('cleanupusers_archive', array('id' => $userarchived->id, 'suspended' => 1,
             'deleted' => 0, 'lastaccess' => $unixoneyearnintydays, 'username' => 's_other07'), true,
             false, true);
         $data['s_other07'] = $userarchived;
@@ -85,9 +85,9 @@ class userstatus_userstatuswwu_generator extends testing_data_generator {
 
         $deleteme = $generator->create_user(array('username' => 'anonym', 'lastaccess' => $unixoneyearnintydays,
             'suspended' => 1, 'firstname' => 'Anonym'));
-        $DB->insert_record_raw('tool_deprovisionuser', array('id' => $deleteme->id, 'archived' => true,
+        $DB->insert_record_raw('tool_cleanupusers', array('id' => $deleteme->id, 'archived' => true,
             'timestamp' => $unixoneyearnintydays), true, false, true);
-        $DB->insert_record_raw('deprovisionuser_archive', array('id' => $deleteme->id, 'suspended' => 1,
+        $DB->insert_record_raw('cleanupusers_archive', array('id' => $deleteme->id, 'suspended' => 1,
             'deleted' => 0, 'lastaccess' => $unixoneyearnintydays, 'username' => 'd_me09'), true,
             false, true);
         $data['d_me09'] = $deleteme;

--- a/userstatus/userstatuswwu/tests/userstatus_userstatuswwu_test.php
+++ b/userstatus/userstatuswwu/tests/userstatus_userstatuswwu_test.php
@@ -51,10 +51,10 @@ class userstatus_userstatuswwu_testcase extends advanced_testcase {
         global $CFG, $USER;
         $data = $this->set_up();
         $this->assertFileExists($CFG->dirroot .
-            '/admin/tool/deprovisionuser/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
+            '/admin/tool/cleanupusers/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
 
         $myuserstatuschecker = new userstatuswwu($CFG->dirroot .
-            '/admin/tool/deprovisionuser/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt',
+            '/admin/tool/cleanupusers/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt',
             array('member_group' => 'member_group', 'member' => 'member'));
         // Calls for plugin function to return array.
         $returnsuspend = $myuserstatuschecker->get_to_suspend();
@@ -111,7 +111,7 @@ class userstatus_userstatuswwu_testcase extends advanced_testcase {
 
         // Userstatuschecker uses default groups. Merely e_user03 is a valid member.
         $myuserstatuschecker = new userstatuswwu($CFG->dirroot .
-            '/admin/tool/deprovisionuser/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
+            '/admin/tool/cleanupusers/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
         $returnsuspend = $myuserstatuschecker->get_to_suspend();
         $returndelete = $myuserstatuschecker->get_to_delete();
         $returnneverloggedin = $myuserstatuschecker->get_never_logged_in();
@@ -142,9 +142,9 @@ class userstatus_userstatuswwu_testcase extends advanced_testcase {
         $data = $this->set_up();
 
         $this->assertFileExists($CFG->dirroot .
-            '/admin/tool/deprovisionuser/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
+            '/admin/tool/cleanupusers/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
         set_config('pathtotxt', $CFG->dirroot .
-            '/admin/tool/deprovisionuser/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt', 'userstatus_userstatuswwu');
+            '/admin/tool/cleanupusers/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt', 'userstatus_userstatuswwu');
         $userstatuswwu = new userstatuswwu();
         $returnsuspend = $userstatuswwu->get_to_suspend();
         $returndelete = $userstatuswwu->get_to_delete();
@@ -178,7 +178,7 @@ class userstatus_userstatuswwu_testcase extends advanced_testcase {
     public function test_filenotexist() {
         global $CFG;
         $this->assertFileExists($CFG->dirroot .
-            '/admin/tool/deprovisionuser/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
+            '/admin/tool/cleanupusers/userstatus/userstatuswwu/tests/_files/groups_excerpt_short.txt');
 
         $this->expectException('userstatus_userstatuswwu\userstatuswwu_exception');
         $this->expectExceptionMessage('The reference to the .txt could not be found.');

--- a/userstatus/userstatuswwu/version.php
+++ b/userstatus/userstatuswwu/version.php
@@ -16,7 +16,7 @@
 
 /**
  * Version details
- * @package deprovisionuser_userstatuswwu
+ * @package userstatus_userstatuswwu
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -29,4 +29,4 @@ $plugin->component = 'userstatus_userstatuswwu'; // Full name of the plugin (use
 $plugin->release = 'v1.0-r0';
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->dependencies = array(
-    'tool_deprovisionuser' => ANY_VERSION);
+    'tool_cleanupusers' => ANY_VERSION);

--- a/version.php
+++ b/version.php
@@ -16,15 +16,15 @@
 
 /**
  * Version details
- * @package tool_deprovisionuser
+ * @package tool_cleanupusers
  * @copyright 2016 N Herrmann
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017040500;     // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2018021300;     // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2016052300;     // Requires 31 Moodle version.
-$plugin->component = 'tool_deprovisionuser'; // Full name of the plugin (used for diagnostics).
-$plugin->release = 'v1.0-r0';
+$plugin->component = 'tool_cleanupusers'; // Full name of the plugin (used for diagnostics).
+$plugin->release = 'v1.0-r1';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
In order to be consistent with our other plugin, `tool_cleanupcourses`, we rename this plugin to `tool_cleanupusers`. This was hinted at by the repository name for some time and is now in effect. 

As the plugin is in alpha and still work-in-progress we do not provide automated upgrade steps, sorry. If you ran a previous version, you will need to rename the following database tables after upgrade (substituting `mdl_` for your own prefix):

`mdl_tool_deprovisionuser` -> `mdl_tool_cleanupusers`
`mdl_deprovisionuser_archive` -> `mdl_tool_cleanupusers_archive`