### PR TITLE
Add default values to archiveduser

### DIFF
--- a/classes/archiveduser.php
+++ b/classes/archiveduser.php
@@ -225,6 +225,7 @@ class archiveduser {
         $cloneuser->firstname = get_config('tool_cleanupusers_settings', 'suspendfirstname');
         $cloneuser->lastname = '';
         $cloneuser->suspended = 1;
+        $cloneuser->idnumber = '';
         $cloneuser->email = '';
         $cloneuser->phone1 = '';
         $cloneuser->phone2 = '';
@@ -233,12 +234,13 @@ class archiveduser {
         $cloneuser->address = '';
         $cloneuser->city = '';
         $cloneuser->country = '';
-        $cloneuser->lang = '';
-        $cloneuser->calendartype = '';
+        $cloneuser->lang = 'en';
+        $cloneuser->calendartype = 'gregorian';
         $cloneuser->firstaccess = 0;
         $cloneuser->lastaccess = 0;
         $cloneuser->currentlogin = 0;
         $cloneuser->lastlogin = 0;
+        $cloneuser->lastip = '';
         $cloneuser->secret = '';
         $cloneuser->picture = 0;
         $cloneuser->description = '';


### PR DESCRIPTION
Hello everyone,

Warnings are issued during execution of the task. Default user settings are not as expected.  
To avoid this, I have added some defaults and attributes, for example `lang` = `en`.

Best regards,
Elke