### PR TITLE
fix: Language string-identifier collision

### DIFF
--- a/classes/table/never_logged_in_table.php
+++ b/classes/table/never_logged_in_table.php
@@ -48,7 +48,7 @@ class never_logged_in_table extends \table_sql {
         $this->define_columns($columns);
 
         // Define the titles of columns to show in header.
-        $headers = [get_string('id', 'tool_cleanupusers'), get_string('Neverloggedin', 'tool_cleanupusers'),
+        $headers = [get_string('id', 'tool_cleanupusers'), get_string('neverloggedin_header', 'tool_cleanupusers'),
             get_string('fullname'), get_string('Archived', 'tool_cleanupusers'), 'Archive'];
         $this->define_headers($headers);
 

--- a/classes/table/users_table.php
+++ b/classes/table/users_table.php
@@ -50,7 +50,7 @@ class users_table extends \table_sql {
         $this->define_columns($columns);
 
         // Define the titles of columns to show in header.
-        $headers = [get_string('id', 'tool_cleanupusers'), get_string('Neverloggedin', 'tool_cleanupusers'),
+        $headers = [get_string('id', 'tool_cleanupusers'), get_string('neverloggedin_header', 'tool_cleanupusers'),
         get_string('fullname'), get_string('lastaccess', 'tool_cleanupusers')];
         $this->define_headers($headers);
 

--- a/lang/en/tool_cleanupusers.php
+++ b/lang/en/tool_cleanupusers.php
@@ -23,7 +23,7 @@
  */
 
 $string['Archived'] = 'Archived:';
-$string['Neverloggedin'] = 'Users that never logged in:';
+$string['neverloggedin_header'] = 'Users that never logged in:';
 $string['No'] = 'No';
 $string['Willbe'] = 'Will be:';
 $string['Yes'] = 'Yes';
@@ -48,7 +48,7 @@ $string['hideuser'] = 'Suspend User';
 $string['id'] = 'ID';
 $string['lastaccess'] = 'Last access:';
 $string['neverlogged'] = 'Never logged in';
-$string['neverloggedin'] = 'Manage users who never logged in';
+$string['neverloggedin_title'] = 'Manage users who never logged in';
 $string['nothinghappens'] = 'Not handled since the user never logged in';
 $string['pluginname'] = 'Clean up users';
 $string['pluginsettingstitle'] = 'General settings';

--- a/neverloggedin.php
+++ b/neverloggedin.php
@@ -37,7 +37,7 @@ require_capability('moodle/site:config', $context);
 
 admin_externalpage_setup('cleanupusers');
 
-$pagetitle = get_string('neverloggedin', 'tool_cleanupusers');
+$pagetitle = get_string('neverloggedin_title', 'tool_cleanupusers');
 $PAGE->set_title($pagetitle);
 $PAGE->set_heading($pagetitle);
 $PAGE->set_pagelayout('standard');

--- a/renderer.php
+++ b/renderer.php
@@ -78,7 +78,7 @@ class tool_cleanupusers_renderer extends plugin_renderer_base {
                 get_string('Willbe', 'tool_cleanupusers')]);
         }
         if (!empty($renderneverloggedin)) {
-            $output .= $this->render_table_of_users($renderneverloggedin, [get_string('Neverloggedin', 'tool_cleanupusers'),
+            $output .= $this->render_table_of_users($renderneverloggedin, [get_string('neverloggedin_header', 'tool_cleanupusers'),
                 get_string('lastaccess', 'tool_cleanupusers'), get_string('Archived', 'tool_cleanupusers'),
                 get_string('Willbe', 'tool_cleanupusers')]);
         }

--- a/settings.php
+++ b/settings.php
@@ -59,7 +59,7 @@ if ($hassiteconfig) {
     // Add entry for own settings.
     $ADMIN->add('tool_cleanupusers', new admin_externalpage(
         'Manage never logged in',
-        get_string('neverloggedin', 'tool_cleanupusers'),
+        get_string('neverloggedin_title', 'tool_cleanupusers'),
         "$CFG->wwwroot/$CFG->admin/tool/cleanupusers/neverloggedin.php"
     ));
     // Add entry for own settings.


### PR DESCRIPTION
The language component file [lang/en/tool_cleanupusers.php](https://github.com/eLearning-TUDarmstadt/moodle-tool_cleanupusers/blob/master/lang/en/tool_cleanupusers.php) contains two string-identifiers for language customisation

```php
$string['Neverloggedin'] = 'Users that never logged in:';
$string['neverloggedin'] = 'Manage users who never logged in';
```

on which a collision may or may not occur, depending on the database setup, whether string fields are case-sensitive or case-insensitive. For me this error applies for SQL Server which is configured as case-insensitive.

### The issue

```
Error writing to database

Debug info: SQLState: 23000<br>
Error Code: 2601<br>
Message: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot insert duplicate key row in object 'dbo.mdl_tool_customlang' with unique index 'mdl_toolcust_lancomstr_uix'. The duplicate key value is (de, 666, neverloggedin).<br>
SQLState: 01000<br>
Error Code: 3621<br>
Message: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The statement has been terminated.<br>

INSERT INTO mdl_tool_customlang (lang,componentid,stringid,original,master,timemodified,outdated,local,timecustomized) VALUES(N'de','666',N'neverloggedin',N'Manage users who never logged in',N'Manage users who never logged in','1750931753','0',NULL,NULL)
[array (
0 => 'de',
1 => '666',
2 => 'neverloggedin',
3 => 'Manage users who never logged in',
4 => 'Manage users who never logged in',
5 => 1750931753,
6 => 0,
7 => NULL,
8 => NULL,
)]
Error code: dmlwriteexception×Dismiss this notification

Stack trace:
line 497 of /lib/dml/moodle_database.php: dml_write_exception thrown
line 331 of /lib/dml/sqlsrv_native_moodle_database.php: call to moodle_database->query_end()
line 438 of /lib/dml/sqlsrv_native_moodle_database.php: call to sqlsrv_native_moodle_database->query_end()
line 1071 of /lib/dml/sqlsrv_native_moodle_database.php: call to sqlsrv_native_moodle_database->do_query()
line 1156 of /lib/dml/sqlsrv_native_moodle_database.php: call to sqlsrv_native_moodle_database->insert_record_raw()
line 208 of /admin/tool/customlang/locallib.php: call to sqlsrv_native_moodle_database->insert_record()
line 63 of /admin/tool/customlang/index.php: call to tool_customlang_utils::checkout()
```

### The cause

IMHO, string identifiers for language customisation should stick to lowercase, only. Always.

### The fix

I simply renamed both string identifiers to my liking. Feel free to change it otherwise.